### PR TITLE
ID-based approach to tracking structure changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ local.envrc
 /.devenv-initialized
 /test-results/.last-run.json
 /test-results/
+
+# LLM
+.playwright-mcp
+
+# Testing
+playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,141 @@
+# AGENTS.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with
+project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial
+tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes,
+simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it
+work") require constant clarification.
+
+## 5. Project-Specific Guidelines
+
+### Domain Documentation
+
+This repo uses the `grill-with-docs` convention for domain documentation. If the
+skill is available, use it before changing `CONTEXT.md`, `CONTEXT-MAP.md`, or
+`docs/adr/*`.
+
+If the skill is not available, tell the user clearly that `grill-with-docs` is
+the preferred workflow before changing these docs. Then use this fallback:
+
+- Start at `CONTEXT-MAP.md` to find the relevant bounded context.
+- Treat `CONTEXT.md` as canonical domain language, not scratch notes.
+- Treat `docs/adr/*` as durable decision records; add new ADRs sparingly.
+- When planning or implementing behavior changes, proactively call out relevant
+  `CONTEXT.md` or ADR updates even if the user did not explicitly ask for docs.
+- Update domain docs only when the domain language, cross-context relationship,
+  or durable decision changes; avoid doc churn for purely mechanical edits.
+
+### Working With The Demo Page To Explore, Test, And Debug
+
+The Vite demo is usually served at `http://localhost:5173/`. Before starting it,
+check whether it is already running, either by inspecting existing terminals or
+by navigating to the local URL with MCP. If it is not running, start it with
+`yarn demo`. When investigating editor behavior, prefer `@playwright/mcp`.
+
+Use Playwright MCP because it is closest to the existing e2e test environment:
+it gives reliable browser actions, accessibility snapshots, keyboard events, and
+page evaluation in one place. Prefer it over Cursor browser tools for
+ProseMirror state inspection, over Chrome DevTools MCP for routine editor
+workflows, and over Playwright CLI/scripts unless the user explicitly asks for a
+script or test.
+
+The demo exposes `window.pmView` as a ProseMirror `EditorView` instance. Use it
+through `browser_evaluate` for JSON-safe inspection and targeted setup, but
+reproduce editor bugs with real keyboard and click interactions whenever
+possible.
+
+Useful MCP tools for editor debugging:
+
+- `browser_evaluate`: inspect `window.pmView`, DOM subtrees, and JSON-safe
+  state.
+- `browser_snapshot`: find controls, refs/selectors, visible state, and optional
+  bounding boxes.
+- `browser_console_messages`: check runtime errors, warnings, and debug logs
+  after a repro.
+
+### Working With The Demo Editor
+
+Use `browser_snapshot` to find controls and confirm visible editor state. Click
+`.ProseMirror` or set a selection with `window.pmView` and call
+`window.pmView.focus()` before sending keyboard input.
+
+To focus a specific visible node, use `browser_click` with a CSS selector in the
+`target` argument, for example `target: ".ProseMirror p:nth-child(3)"`. Be more
+specific for nested structures, since list item paragraphs are not direct
+siblings of top-level paragraphs.
+
+Use `browser_type` with `target: ".ProseMirror"` and `slowly: true` when text
+should pass through ProseMirror input rules character by character, such as
+typing `- ` to start a list. Use `browser_press_key` for editor commands:
+`Enter`, `Backspace`, `Delete`, `Tab`, `Shift+Tab`, arrow keys, and modifier
+shortcuts. Use button clicks for UI actions such as `Apply all` and
+`Revert all`.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer
+rewrites due to overcomplication, and clarifying questions come before
+implementation rather than after mistakes.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -13,24 +13,15 @@
 - [Start-To-Start Textblock Deletion](./src/features/startToStartTextblockDeletion/CONTEXT.md) -
   single replace-step text-selection deletion shapes whose step boundaries
   differ from the user-visible deleted range.
+- [Ensure Valid Selection](./src/features/ensureValidSelection/CONTEXT.md) -
+  cursor and text-selection positions that suggestion markers make unsafe for
+  normal editing.
 
 ## Relationships
 
-This repository has multiple bounded documentation contexts:
-
-- [Wrap/Unwrap Structure Suggestions](./src/features/wrapUnwrap/CONTEXT.md) -
-  tracked suggestions for configured structural context edits such as indent,
-  outdent, wrap, and unwrap.
-- [Join On Delete Suggestions](./src/features/joinOnDelete/CONTEXT.md) - tracked
-  suggestions for physical block joins created by deleting a block boundary.
-- [Transaction Shaping](./src/features/transactionShaping/CONTEXT.md) -
-  recognition of special compound editor transactions that should be expressed
-  as existing suggestion concepts.
-
-## Relationships
-
-- Wrap/unwrap owns **Structure suggestions** and **Structure add suggestions**.
-- Join-on-delete owns **Block join suggestions**.
+- Wrap/unwrap owns the **Structure suggestion** and **Structure add suggestion**
+  concepts.
+- Join-on-delete owns the **Block join suggestion** concept.
 - **Provisional add join cancellation** is the shared rule: when a physical
   block join touches any node with a Structure add suggestion, the join happens
   but no separate Block join suggestion is created.
@@ -40,3 +31,5 @@ This repository has multiple bounded documentation contexts:
   edit, those existing concepts may share one suggestion ID.
 - Start-to-start textblock deletion is handled inside normal replace-step
   suggestion tracking; it does not inspect or rewrite whole transactions.
+- Ensure-valid-selection runs after transactions and may rewrite invalid text
+  selections without changing the document.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -2,20 +2,19 @@
 
 ## Contexts
 
-- [Wrap/Unwrap Structure Suggestions](./src/features/wrapUnwrap/CONTEXT.md) -
-  tracked suggestions for configured structural context edits such as indent,
-  outdent, wrap, and unwrap.
-- [Join On Delete Suggestions](./src/features/joinOnDelete/CONTEXT.md) - tracked
-  suggestions for physical block joins created by deleting a block boundary.
-- [Transaction Shaping](./src/features/transactionShaping/CONTEXT.md) -
-  recognition of special compound editor transactions that should be expressed
-  as existing suggestion concepts.
-- [Start-To-Start Textblock Deletion](./src/features/startToStartTextblockDeletion/CONTEXT.md) -
-  single replace-step text-selection deletion shapes whose step boundaries
-  differ from the user-visible deleted range.
-- [Ensure Valid Selection](./src/features/ensureValidSelection/CONTEXT.md) -
-  cursor and text-selection positions that suggestion markers make unsafe for
-  normal editing.
+Context docs live under `src`.
+
+- Wrap/Unwrap Structure Suggestions - tracked suggestions for configured
+  structural context edits such as indent, outdent, wrap, and unwrap.
+- Join On Delete Suggestions - tracked suggestions for physical block joins
+  created by deleting a block boundary.
+- Transaction Shaping - recognition of special compound editor transactions that
+  should be expressed as existing suggestion concepts.
+- Start-To-Start Textblock Deletion - single replace-step text-selection
+  deletion shapes whose step boundaries differ from the user-visible deleted
+  range.
+- Ensure Valid Selection - cursor and text-selection positions that suggestion
+  markers make unsafe for normal editing.
 
 ## Relationships
 

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -16,6 +16,19 @@
 
 ## Relationships
 
+This repository has multiple bounded documentation contexts:
+
+- [Wrap/Unwrap Structure Suggestions](./src/features/wrapUnwrap/CONTEXT.md) -
+  tracked suggestions for configured structural context edits such as indent,
+  outdent, wrap, and unwrap.
+- [Join On Delete Suggestions](./src/features/joinOnDelete/CONTEXT.md) - tracked
+  suggestions for physical block joins created by deleting a block boundary.
+- [Transaction Shaping](./src/features/transactionShaping/CONTEXT.md) -
+  recognition of special compound editor transactions that should be expressed
+  as existing suggestion concepts.
+
+## Relationships
+
 - Wrap/unwrap owns **Structure suggestions** and **Structure add suggestions**.
 - Join-on-delete owns **Block join suggestions**.
 - **Provisional add join cancellation** is the shared rule: when a physical
@@ -23,6 +36,7 @@
   but no separate Block join suggestion is created.
 - Transaction shaping may split a recognized compound transaction into existing
   Structure suggestion and Block join suggestion tracking paths; it does not
-  introduce a separate suggestion type.
+  introduce a separate suggestion type. When the recognized shape is one visible
+  edit, those existing concepts may share one suggestion ID.
 - Start-to-start textblock deletion is handled inside normal replace-step
   suggestion tracking; it does not inspect or rewrite whole transactions.

--- a/demo/main.css
+++ b/demo/main.css
@@ -20,6 +20,7 @@ ins,
 [data-node-insertion] {
   background-color: #baffdf;
   color: #00973c;
+  mix-blend-mode: multiply;
 }
 
 del,
@@ -32,4 +33,16 @@ del,
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+}
+
+[data-type="structure"] {
+  background-color: #b3d9ff;
+  color: #005c99;
+  mix-blend-mode: multiply;
+}
+
+blockquote {
+  border-left: 2px solid #000;
+  padding-left: 1rem;
+  margin-left: 1rem;
 }

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -134,10 +134,11 @@ const remarkProseMirrorOptions: RemarkProseMirrorOptions = {
   },
 };
 
-const content = `- Item 0
-- Item 1
+const content = `- Item 1
 - Item 2
 - Item 3
+- Item 4
+- Item 5
 `;
 
 const doc = await unified()

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -4,11 +4,19 @@ import {
   toPmMark,
   toPmNode,
 } from "@handlewithcare/remark-prosemirror";
-import { baseKeymap, chainCommands, toggleMark } from "prosemirror-commands";
+import {
+  baseKeymap,
+  chainCommands,
+  exitCode,
+  lift,
+  toggleMark,
+  wrapIn,
+} from "prosemirror-commands";
 import { history, redo, undo } from "prosemirror-history";
-import { inputRules, wrappingInputRule } from "prosemirror-inputrules";
+import { inputRules } from "prosemirror-inputrules";
 import { keymap } from "prosemirror-keymap";
-import { EditorState, Plugin } from "prosemirror-state";
+import { EditorState, Plugin, type Transaction } from "prosemirror-state";
+import { type Mark, type Node } from "prosemirror-model";
 import {
   applySuggestions,
   enableSuggestChanges,
@@ -18,10 +26,12 @@ import {
   toggleSuggestChanges,
   withSuggestChanges,
   experimental_ensureSelection,
+  addSuggestionMarks,
+  suggestChangesKey,
+  revertSuggestion,
 } from "../src/index.js";
 import { EditorView } from "prosemirror-view";
 import "prosemirror-view/style/prosemirror.css";
-import { nodes, marks } from "prosemirror-schema-basic";
 import {
   bulletList,
   liftListItem,
@@ -30,37 +40,70 @@ import {
   sinkListItem,
   splitListItem,
 } from "prosemirror-schema-list";
-import { addSuggestionMarks } from "../src/index.js";
-import { Schema } from "prosemirror-model";
 import "./main.css";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
+import { Schema } from "prosemirror-model";
+import { marks, nodes as schemaNodes } from "prosemirror-schema-basic";
+import { addIdAttr } from "../src/features/wrapUnwrap/addIdAttr.js";
+import {
+  ensureUniqueNodeIds,
+  uniqueNodeIdsPlugin,
+} from "../src/features/wrapUnwrap/uniqueNodeIdsPlugin.js";
+import { getSuggestionMarks } from "../src/utils.js";
+import { Step, Transform } from "prosemirror-transform";
+import { revertStructureMark } from "../src/features/wrapUnwrap/revert/revertStructureSuggestions.js";
+import { listInputRules } from "../src/listInputRules.js";
+import { type SuggestionId } from "../src/generateId.js";
+
+// stable node ids for demo
+let nodeId = 0;
+const generateUniqueNodeId = () => {
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+  return `node-${nodeId++}`;
+};
+
+const nodes = { ...schemaNodes };
+for (const [key, nodeSpec] of Object.entries(nodes)) {
+  nodes[key] = addIdAttr(nodeSpec);
+}
+
+const listNodes = { orderedList, bulletList, listItem };
+for (const [key, nodeSpec] of Object.entries(listNodes)) {
+  listNodes[key] = addIdAttr(nodeSpec);
+}
 
 export const schema = new Schema({
   nodes: {
     ...nodes,
+    doc: { ...nodes.doc, marks: "insertion deletion modification structure" },
     image: { ...nodes.image, group: "block", inline: false },
-    doc: { ...nodes.doc, marks: "insertion deletion modification" },
-    ordered_list: {
-      ...orderedList,
+    blockquote: {
+      ...nodes.blockquote,
       group: "block",
-      content: "list_item+",
-      marks: "insertion deletion modification",
+      marks: "insertion deletion modification structure",
     },
-    bullet_list: {
-      ...bulletList,
+    orderedList: {
+      ...listNodes.orderedList,
       group: "block",
-      content: "list_item+",
-      marks: "insertion deletion modification",
+      content: "listItem+",
+      marks: "insertion deletion modification structure",
     },
-    list_item: {
-      ...listItem,
-      content: "block+",
-      marks: "insertion deletion modification",
+    bulletList: {
+      ...listNodes.bulletList,
+      group: "block",
+      content: "listItem+",
+      marks: "insertion deletion modification structure",
     },
+    listItem: {
+      ...listNodes.listItem,
+      content: "paragraph block*",
+      marks: "insertion deletion modification structure",
+    },
+    hardBreak: { ...nodes.hard_break },
   },
   marks: addSuggestionMarks(marks, {
-    experimental_deletions: "hidden",
+    experimental_deletions: "visible",
   }),
 });
 
@@ -72,13 +115,13 @@ const remarkProseMirrorOptions: RemarkProseMirrorOptions = {
       level: node.depth,
     })),
     code(node) {
-      return schema.nodes.code_block.create({}, schema.text(node.value));
+      return schema.nodes.codeBlock.create({}, schema.text(node.value));
     },
     image: toPmNode(schema.nodes.image, (node) => ({
       url: node.url,
     })),
-    list: toPmNode(schema.nodes.bullet_list),
-    listItem: toPmNode(schema.nodes.list_item),
+    list: toPmNode(schema.nodes.orderedList),
+    listItem: toPmNode(schema.nodes.listItem),
     emphasis: toPmMark(schema.marks.em),
     strong: toPmMark(schema.marks.strong),
     inlineCode(node) {
@@ -91,17 +134,10 @@ const remarkProseMirrorOptions: RemarkProseMirrorOptions = {
   },
 };
 
-const content = `# This is the \`@handlewithcare/prosemirror-suggest-changes\` demo editor!
-
-Suggestions are enabled to start, so start typing and see how it works! Here are
-some use cases to try out:
-
-- Inserting and deleting plain text
-- Inserting new paragraphs, and deleting across existing paragraph boundaries
-- Using undo and redo (cmd/ctrl+z and cmd/ctrl+shift+z)
-- Applying and reverting all suggestions
-
-You can also use the button above the editor to disable suggestions.
+const content = `- Item 0
+- Item 1
+- Item 2
+- Item 3
 `;
 
 const doc = await unified()
@@ -115,32 +151,51 @@ const enterCommand = baseKeymap["Enter"];
 if (!enterCommand) {
   throw new Error("Missing enter command");
 }
+
+// add a hard break on Mod+Enter
+// https://code.haverbeke.berlin/prosemirror/prosemirror-example-setup/src/tag/1.2.3/src/keymap.ts#L76
+const hardBreakCommand = chainCommands(exitCode, (state, dispatch) => {
+  if (dispatch)
+    dispatch(
+      state.tr
+        .replaceSelectionWith(schema.nodes.hardBreak.create())
+        .scrollIntoView(),
+    );
+  return true;
+});
+
 const editorState = EditorState.create({
   schema,
   doc,
   plugins: [
-    experimental_ensureSelection(),
+    uniqueNodeIdsPlugin({
+      attributeName: "id",
+      generateID: generateUniqueNodeId,
+    }),
     keymap({
       ...baseKeymap,
-      Enter: chainCommands(splitListItem(schema.nodes.list_item), enterCommand),
+      Enter: chainCommands(splitListItem(schema.nodes.listItem), enterCommand),
       "Shift-Enter": enterCommand,
-      Tab: sinkListItem(schema.nodes.list_item),
-      "Shift-Tab": liftListItem(schema.nodes.list_item),
+      "Mod-Enter": hardBreakCommand,
+      Tab: sinkListItem(schema.nodes.listItem),
+      "Shift-Tab": liftListItem(schema.nodes.listItem),
       "Mod-i": toggleMark(schema.marks.em),
       "Mod-b": toggleMark(schema.marks.strong),
       "Mod-Shift-c": toggleMark(schema.marks.code),
       "Mod-z": undo,
       "Mod-Shift-z": redo,
       "Mod-y": redo,
+      "Mod-u": wrapIn(schema.nodes.blockquote),
+      "Mod-l": lift,
     }),
     inputRules({
       rules: [
-        wrappingInputRule(/^\s*([-+*])\s$/, schema.nodes.bullet_list),
-        wrappingInputRule(/^\s*([0-9]+\.)\s$/, schema.nodes.ordered_list),
+        ...listInputRules(schema.nodes.bulletList, schema.nodes.orderedList),
       ],
     }),
     history(),
     suggestChanges(),
+    experimental_ensureSelection(),
   ],
 });
 
@@ -202,7 +257,138 @@ const editorEl = document.getElementById("editor")!;
 const view = new EditorView(editorEl, {
   state: editorState,
   plugins,
-  dispatchTransaction: withSuggestChanges(),
+  dispatchTransaction: withSuggestChanges(
+    function (this: EditorView, tr: Transaction) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const view = this;
+      const { structure, deletion } = getSuggestionMarks(this.state.schema);
+
+      const newState = this.state.apply(tr);
+
+      const structureMarks: { node: Node; mark: Mark; pos: number }[] = [];
+      newState.doc.descendants((node, pos) => {
+        node.marks.forEach((mark) => {
+          if (mark.type === structure) structureMarks.push({ node, mark, pos });
+        });
+        return true;
+      });
+
+      const deletionMarks: {
+        node: Node;
+        parent: Node | null;
+        mark: Mark;
+        pos: number;
+      }[] = [];
+      newState.doc.descendants((node, pos, parent) => {
+        node.marks.forEach((mark) => {
+          if (mark.type === deletion)
+            deletionMarks.push({ node, parent, mark, pos });
+        });
+        return true;
+      });
+
+      setTimeout(() => {
+        const elements: HTMLElement[] = [];
+        structureMarks.forEach((mark) => {
+          const element = document.createElement("button");
+          element.addEventListener("click", () => {
+            const transform = new Transform(view.state.doc);
+            revertStructureMark(transform, mark.mark, mark.pos);
+            const tr = view.state.tr;
+            transform.steps.forEach((step) => tr.step(step));
+            tr.setMeta(suggestChangesKey, { skip: true });
+            view.dispatch(tr);
+          });
+          element.textContent = `Revert structure mark id="${mark.mark.attrs["id"] as string}" on node ${mark.node.toString()}`;
+          elements.push(element);
+        });
+
+        const container = document.createElement("div");
+        container.id = "structure-marks";
+        container.append(...elements);
+
+        const parent = view.dom.parentElement;
+        const existing = parent?.querySelector("#structure-marks");
+        if (existing) parent?.removeChild(existing);
+        parent?.append(container);
+      }, 0);
+
+      setTimeout(() => {
+        const elements: HTMLElement[] = [];
+        deletionMarks.forEach((mark) => {
+          const element = document.createElement("button");
+          element.addEventListener("click", () => {
+            revertSuggestion(mark.mark.attrs["id"] as SuggestionId)(
+              view.state,
+              view.dispatch,
+            );
+          });
+          element.textContent = `Revert deletion mark id="${mark.mark.attrs["id"] as string}" on node ${mark.node.toString()} in parent ${mark.parent?.toString() ?? "null"}`;
+          elements.push(element);
+        });
+
+        const container = document.createElement("div");
+        container.id = "deletion-marks";
+        container.append(...elements);
+
+        const parent = view.dom.parentElement;
+        const existing = parent?.querySelector("#deletion-marks");
+        if (existing) parent?.removeChild(existing);
+        parent?.append(container);
+      });
+
+      this.updateState(newState);
+    },
+    undefined,
+    {
+      experimental_trackStructureChanges: true,
+      experimental_trackStructures: [
+        ["orderedList", "listItem"],
+        ["bulletList", "listItem"],
+        ["blockquote"],
+      ],
+      experimental_ensureUniqueNodeIds: (
+        transactions: Transaction[],
+        oldDoc: Node,
+        newDoc: Node,
+      ) =>
+        ensureUniqueNodeIds(transactions, oldDoc, newDoc, {
+          attributeName: "id",
+          generateID: generateUniqueNodeId,
+        }),
+    },
+  ),
 });
 
 enableSuggestChanges(view.state, view.dispatch);
+
+declare global {
+  interface Window {
+    pmView: EditorView;
+    dispatchTransactionWithSteps: (stepJSONs: object[]) => void;
+    replaceDoc: (docJSON: unknown) => void;
+  }
+}
+
+window.pmView = view;
+
+window.dispatchTransactionWithSteps = (stepJSONs: object[]) => {
+  const steps = stepJSONs.map((stepJSON) => Step.fromJSON(schema, stepJSON));
+  const tr = view.state.tr;
+  steps.forEach((step) => tr.step(step));
+  view.dispatch(tr);
+};
+
+window.replaceDoc = (docJSON: unknown) => {
+  const schema = view.state.schema;
+  const doc = schema.nodeFromJSON(docJSON);
+
+  // Create a completely new state with the new document
+  const newState = EditorState.create({
+    doc,
+    schema,
+    plugins: view.state.plugins,
+  });
+
+  view.updateState(newState);
+};

--- a/docs/superpowers/specs/2026-06-30-structure-mark-role-design.md
+++ b/docs/superpowers/specs/2026-06-30-structure-mark-role-design.md
@@ -1,0 +1,151 @@
+# Structure Mark Roles Design
+
+## Context
+
+Structure suggestions currently mark every stable content node whose parent
+chain changes across a configured structural context. This preserves revert
+correctness, but it can expose implementation details to users.
+
+For example, outdenting a middle list item splits the original list into two
+lists. The outdented item is the user-visible change, but the items below it
+also receive Structure marks because their parent list wrapper was recreated.
+That is technically accurate, but product users expect only the outdented item
+to look changed.
+
+## Goals
+
+- Visually mark only the item the user semantically changed.
+- Keep collateral Structure marks available for apply/revert bookkeeping.
+- Preserve current apply/revert behavior by suggestion ID.
+- Keep existing documents compatible: role-less Structure marks are visible.
+- Keep the first implementation small and scoped to Structure suggestions.
+
+## Non-Goals
+
+- Do not change review-control grouping in Marker.
+- Do not change demo debugging controls to hide supporting marks.
+- Do not move supporting operations into the primary mark.
+- Do not redesign the tree-diff or Structure suggestion model.
+
+## Structure Mark Role
+
+Add optional role metadata to Structure mark data:
+
+```ts
+type StructureMarkRole = "primary" | "supporting";
+
+type StructureMarkData = {
+  op: Op;
+  role?: StructureMarkRole;
+};
+```
+
+Role-less marks are treated as `primary`.
+
+`primary` means the mark represents the user-visible structural change.
+`supporting` means the mark exists to preserve apply/revert correctness for
+collateral wrapper movement, but should not receive product-visible Structure
+styling.
+
+## DOM Projection
+
+`schema.ts` should project the effective role into the Structure mark DOM:
+
+```html
+<div data-type="structure" data-role="primary">
+```
+
+Role-less or unknown role values should render as `data-role="primary"`.
+Supporting marks should render as `data-role="supporting"`.
+
+Product CSS can then style only primary Structure marks:
+
+```css
+div[data-type="structure"][data-role="primary"] {
+  /* visible structure styling */
+}
+```
+
+Supporting marks must not be hidden with `display: none`, because the mark wraps
+real document content. They simply should not receive visible change styling.
+
+## Classification
+
+Classification happens after Structure operations are detected for one
+suggestion and before Structure marks are added to the document.
+
+Rules:
+
+- `add` operations are always `primary`.
+- `move` operations are `primary` when the content node crosses a configured
+  structural context boundary.
+- `move` operations are `supporting` when all are true:
+  - the same suggestion group contains at least one primary boundary move;
+  - the move keeps the same configured structural context depth;
+  - the move keeps the same innermost content-owning structural parent, such as
+    the same `listItem` ID;
+  - an outer structural wrapper changed, such as a list node being split or
+    recreated.
+- Uncertain cases default to `primary`.
+
+The classifier should be conservative. It should only hide moves that look like
+collateral wrapper recreation around a real primary structural edit.
+
+### Middle Outdent Example
+
+Before:
+
+```text
+orderedList
+  listItem -> paragraph("Item One")
+  listItem -> paragraph("Item Two")
+  listItem -> paragraph("Item Three")
+  listItem -> paragraph("Item Four")
+  listItem -> paragraph("Item Five")
+```
+
+After outdenting `Item Three`:
+
+```text
+orderedList
+  listItem -> paragraph("Item One")
+  listItem -> paragraph("Item Two")
+paragraph("Item Three")
+orderedList
+  listItem -> paragraph("Item Four")
+  listItem -> paragraph("Item Five")
+```
+
+Roles:
+
+- `Item Three`: `primary`, because it leaves the list structural context.
+- `Item Four`: `supporting`, because it remains inside the same list item and
+  list depth, but its outer list wrapper was recreated.
+- `Item Five`: `supporting`, for the same reason as `Item Four`.
+
+All three marks keep the same suggestion ID.
+
+## Apply And Revert Behavior
+
+Apply/revert behavior remains suggestion-ID based. Applying or reverting the
+visible primary suggestion handles primary and supporting marks together.
+
+Directly reverting an individual supporting mark may remain possible in demo or
+debug tooling. Product review UI should not create actions from supporting
+marks, but Marker already groups review controls by suggestion ID, so control
+cardinality does not need to change.
+
+## Verification
+
+Implementation should first prove it does not disturb existing behavior by
+running the full unit and e2e suite unchanged.
+
+Add at most one focused e2e assertion around the existing middle-outdent path:
+
+- outdenting `Item Three` still creates three Structure marks;
+- exactly one mark is primary or role-less-visible;
+- exactly two marks are `supporting`;
+- the existing revert-all assertion still restores the original list.
+
+Do not add a broad new e2e matrix initially. Add unit classifier coverage later
+only if the implementation shape proves hard to trust without it.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-marker/prosemirror-suggest-changes",
-  "version": "0.4.1-wrap-unwrap.0",
+  "version": "0.4.1-wrap-unwrap.1",
   "license": "MIT",
   "type": "module",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-marker/prosemirror-suggest-changes",
-  "version": "0.4.1-wrap-unwrap.2",
+  "version": "0.4.1-wrap-unwrap.3",
   "license": "MIT",
   "type": "module",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-marker/prosemirror-suggest-changes",
-  "version": "0.4.1-wrap-unwrap.1",
+  "version": "0.4.1-wrap-unwrap.2",
   "license": "MIT",
   "type": "module",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-marker/prosemirror-suggest-changes",
-  "version": "0.4.0",
+  "version": "0.4.1-wrap-unwrap.0",
   "license": "MIT",
   "type": "module",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-marker/prosemirror-suggest-changes",
-  "version": "0.4.1-wrap-unwrap.3",
+  "version": "0.4.1-wrap-unwrap.4",
   "license": "MIT",
   "type": "module",
   "module": "dist/index.js",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,10 +8,15 @@ export default defineConfig<TestOptions>({
   forbidOnly: !!process.env["CI"],
   retries: process.env["CI"] ? 2 : 0,
   ...(process.env["CI"] ? { workers: 1 } : {}),
-  reporter: "list",
+  reporter: [
+    ["list"],
+    ["html", { open: process.env["CI"] ? "never" : "on-failure" }],
+  ],
   use: {
     baseURL: "http://localhost:3000",
     trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
   },
   projects: [
     {

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -11,7 +11,7 @@ import {
   revertSuggestion,
   revertSuggestions,
 } from "../commands.js";
-import { deletion, insertion, modification } from "../schema.js";
+import { deletion, insertion, modification, structure } from "../schema.js";
 import { testBuilders } from "../testing/testBuilders.js";
 
 describe("applyTrackedChanges", () => {
@@ -240,6 +240,7 @@ describe("applyTrackedChange", () => {
         insertion: insertionWithAuthor,
         deletion: deletionWithAuthor,
         modification,
+        structure,
       },
     });
     const customBuilders = builders(schemaWithAuthors);

--- a/src/__tests__/editingBehavior.playwright.test.ts
+++ b/src/__tests__/editingBehavior.playwright.test.ts
@@ -3,6 +3,68 @@ import { setupDocFromJSON } from "./playwrightHelpers.js";
 import { EditorPage } from "./playwrightPage.js";
 
 test.describe("General editing behavior around suggestion marks", () => {
+  test("should be able to type after a Mod+Enter hard break in a list item", async ({
+    page,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          attrs: { order: 1 },
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "one" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "two" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "three" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const editorPage = new EditorPage(page);
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+    await editorPage.pressKey("ArrowUp");
+
+    await editorPage.pressKey("ControlOrMeta+Enter");
+    await editorPage.insertText(" after");
+
+    expect(await editorPage.getParagraphText(0, [1])).toBe("two after");
+    expect(await editorPage.getParagraphText(0, [2])).toBe("three");
+
+    const currentDoc = await editorPage.getCurrentDoc();
+    const secondItemParagraph = currentDoc.child(0).child(1).child(0);
+    expect(secondItemParagraph.child(0).text).toBe("two");
+    expect(secondItemParagraph.child(1).type.name).toBe("hardBreak");
+    expect(secondItemParagraph.child(2).text).toBe(" after");
+  });
+
   test("backspacing into a pair of adjacent deletion/insertion marks should delete characters in the insertion", async ({
     page,
   }) => {

--- a/src/__tests__/listCursorPlacement.playwright.test.ts
+++ b/src/__tests__/listCursorPlacement.playwright.test.ts
@@ -1,0 +1,353 @@
+import { PILCROW, ZWSP } from "../constants.js";
+import { test, expect } from "./playwrightBaseTest.js";
+import { setupDocFromJSON } from "./playwrightHelpers.js";
+import { EditorPage } from "./playwrightPage.js";
+
+test.describe("Cursor placement in lists", () => {
+  test("Lands on the new list item from below with track changes disabled", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 3" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 4" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+    await editorPage.focusEditor();
+    await editorPage.disableTrackChanges();
+
+    await expect(editorPage.getListItems()).toHaveCount(4);
+    await expect(editorPage.getParagraphs()).toHaveCount(4);
+
+    // place cursor at "|Item 4"
+    await editorPage.pressKey("Home");
+    // move cursor up to "|Item 3"
+    await editorPage.pressKey("ArrowUp", { waitForSelectionChange: true });
+
+    // press Enter to create a new list item above "Item 3"
+    await editorPage.pressKey("Enter", { waitForSelectionChange: true });
+
+    await expect(editorPage.getListItems()).toHaveCount(5);
+    await expect(editorPage.getParagraphs()).toHaveCount(5);
+
+    await editorPage.setCursorToEnd();
+    // place cursor at "|Item 4"
+    await editorPage.pressKey("Home");
+    // place cursor at the newly created paragraph above
+    await editorPage.pressKeyMultiple("ArrowUp", 2, {
+      waitForSelectionChange: true,
+    });
+
+    // enter some text to verify cursor placement
+    await editorPage.insertText("FOO");
+
+    await expect(editorPage.getParagraphAt(1)).toHaveText("Item 2");
+    await expect(editorPage.getParagraphAt(2)).toHaveText("FOO");
+    await expect(editorPage.getParagraphAt(3)).toHaveText("Item 3");
+  });
+
+  test("Lands on the new list item from above with track changes disabled", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 3" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 4" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+    await editorPage.focusEditor();
+    await editorPage.disableTrackChanges();
+
+    await expect(editorPage.getListItems()).toHaveCount(4);
+    await expect(editorPage.getParagraphs()).toHaveCount(4);
+
+    // place cursor at "|Item 4"
+    await editorPage.pressKey("Home");
+    // move cursor up to "|Item 3"
+    await editorPage.pressKey("ArrowUp", { waitForSelectionChange: true });
+
+    // press Enter to create a new list item above "Item 3"
+    await editorPage.pressKey("Enter", { waitForSelectionChange: true });
+
+    await expect(editorPage.getListItems()).toHaveCount(5);
+    await expect(editorPage.getParagraphs()).toHaveCount(5);
+
+    // place cursor at the start of the document
+    await editorPage.setCursorToStart();
+    // go down to "|Item 2" and then down once more to the new paragraph
+    await editorPage.pressKeyMultiple("ArrowDown", 2, {
+      waitForSelectionChange: true,
+    });
+
+    // enter some text to verify cursor placement
+    await editorPage.insertText("FOO");
+
+    await expect(editorPage.getParagraphAt(1)).toHaveText("Item 2");
+    await expect(editorPage.getParagraphAt(2)).toHaveText("FOO");
+    await expect(editorPage.getParagraphAt(3)).toHaveText("Item 3");
+  });
+
+  test("Lands on the new list item from below with track changes enabled", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 3" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 4" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+    await editorPage.focusEditor();
+    await editorPage.enableTrackChanges();
+
+    await expect(editorPage.getListItems()).toHaveCount(4);
+    await expect(editorPage.getParagraphs()).toHaveCount(4);
+
+    // place cursor at "|Item 4"
+    await editorPage.pressKey("Home");
+    // move cursor up to "|Item 3"
+    await editorPage.pressKey("ArrowUp", { waitForSelectionChange: true });
+
+    // press Enter to create a new list item above "Item 3"
+    await editorPage.pressKey("Enter", { waitForSelectionChange: true });
+
+    await expect(editorPage.getListItems()).toHaveCount(5);
+    await expect(editorPage.getParagraphs()).toHaveCount(5);
+
+    await editorPage.setCursorToEnd();
+    // place cursor at "|Item 4"
+    await editorPage.pressKey("Home");
+    // place cursor at the newly created paragraph above
+    await editorPage.pressKeyMultiple("ArrowUp", 2, {
+      waitForSelectionChange: true,
+    });
+
+    // enter some text to verify cursor placement
+    await editorPage.insertText("FOO");
+
+    await expect(editorPage.getParagraphAt(1)).toHaveText("Item 2");
+    await expect(editorPage.getParagraphAt(2)).toHaveText(
+      `FOO${ZWSP}${PILCROW}`,
+    );
+    await expect(editorPage.getParagraphAt(3)).toHaveText("Item 3");
+  });
+
+  test("Lands on the new list item from above with track changes enabled", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 3" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 4" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+    await editorPage.focusEditor();
+    await editorPage.enableTrackChanges();
+
+    await expect(editorPage.getListItems()).toHaveCount(4);
+    await expect(editorPage.getParagraphs()).toHaveCount(4);
+
+    // place cursor at "|Item 4"
+    await editorPage.pressKey("Home");
+    // move cursor up to "|Item 3"
+    await editorPage.pressKey("ArrowUp", { waitForSelectionChange: true });
+
+    // press Enter to create a new list item above "Item 3"
+    await editorPage.pressKey("Enter", { waitForSelectionChange: true });
+
+    await expect(editorPage.getListItems()).toHaveCount(5);
+    await expect(editorPage.getParagraphs()).toHaveCount(5);
+
+    // place cursor at the start of the document
+    await editorPage.setCursorToStart();
+
+    // go down to "|Item 2" and then down once more to the new paragraph
+    await editorPage.pressKeyMultiple("ArrowDown", 2, {
+      waitForSelectionChange: true,
+    });
+
+    // enter some text to verify cursor placement
+    await editorPage.insertText("FOO");
+
+    await expect(editorPage.getParagraphAt(1)).toHaveText("Item 2");
+    await expect(editorPage.getParagraphAt(2)).toHaveText(
+      `FOO${ZWSP}${PILCROW}`,
+    );
+    await expect(editorPage.getParagraphAt(3)).toHaveText("Item 3");
+  });
+});

--- a/src/__tests__/playwrightHelpers.ts
+++ b/src/__tests__/playwrightHelpers.ts
@@ -178,8 +178,8 @@ export function assertReverted(
  */
 export async function setupDocFromJSON(
   page: Page,
-  docJSON: unknown,
-): Promise<{ initialState: EditorState; initialDoc: unknown }> {
+  docJSON: object,
+): Promise<{ initialState: EditorState; initialDoc: object }> {
   await page.evaluate((json) => {
     window.pmEditor.replaceDoc(json);
   }, docJSON);

--- a/src/__tests__/playwrightPage.ts
+++ b/src/__tests__/playwrightPage.ts
@@ -203,13 +203,10 @@ export class EditorPage {
    * editor.view.state is a different object (ProseMirror creates a new
    * immutable state on every transaction).
    */
-  async insertText(
-    text: string,
-    opts?: { waitForSelectionChange?: boolean },
-  ): Promise<void> {
+  async insertText(text: string): Promise<void> {
     await this.doActionAndWaitForState(
       () => this.page.keyboard.insertText(text),
-      opts,
+      { waitForSelectionChange: true },
     );
   }
 
@@ -230,5 +227,33 @@ export class EditorPage {
     await this.page.evaluate((nextNodeId) => {
       window.pmEditor.setNextNodeId(nextNodeId);
     }, nextNodeId);
+  }
+
+  async enableTrackChanges() {
+    await this.page.evaluate(() => {
+      window.pmEditor.setSuggestChangesEnabled(true);
+    });
+  }
+
+  async disableTrackChanges() {
+    await this.page.evaluate(() => {
+      window.pmEditor.setSuggestChangesEnabled(false);
+    });
+  }
+
+  async focusEditor() {
+    await this.setCursorToEnd();
+  }
+
+  async setCursorToStart() {
+    await this.page.evaluate(() => {
+      window.pmEditor.setCursorToStart();
+    });
+  }
+
+  async setCursorToEnd() {
+    await this.page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
   }
 }

--- a/src/__tests__/playwrightPage.ts
+++ b/src/__tests__/playwrightPage.ts
@@ -1,31 +1,60 @@
+import { type Node } from "prosemirror-model";
 import { type Locator, type Page } from "@playwright/test";
+import { createSchema } from "../testing/e2eTestSchema.js";
 
 export class EditorPage {
   readonly page: Page;
+  readonly deletionMarksVisibility: "hidden" | "visible";
 
   private readonly selectors = {
     editor: '[data-testid="main-editor"]',
   };
 
-  constructor(page: Page) {
+  constructor(
+    page: Page,
+    deletionMarksVisibility: "hidden" | "visible" = "visible",
+  ) {
     this.page = page;
+    this.deletionMarksVisibility = deletionMarksVisibility;
   }
 
   get editor(): Locator {
     return this.page.locator(this.selectors.editor);
   }
 
-  async getParagraphText(index: number): Promise<string> {
+  async getParagraphText(
+    index: number,
+    childIndexes?: number[],
+  ): Promise<string> {
     return await this.page.evaluate(
-      ({ index }) => {
-        return window.pmEditor.getTextContentOfChildAtIndex(index);
+      ({ index, childIndexes }) => {
+        return window.pmEditor.getTextContentOfChildAtIndex(
+          index,
+          childIndexes,
+        );
       },
-      { index },
+      { index, childIndexes },
     );
+  }
+
+  getParagraphAt(index: number): Locator {
+    return this.editor.locator("p").nth(index);
   }
 
   async getParagraphCount(): Promise<number> {
     return await this.editor.locator("p").count();
+  }
+
+  getListItems(): Locator {
+    return this.editor.locator("li");
+  }
+
+  getParagraphs(): Locator {
+    return this.editor.locator("p");
+  }
+
+  async getListItemCount(): Promise<number> {
+    return await this.editor.locator("li").count();
   }
 
   async getProseMirrorMarkCount(name: string): Promise<number> {
@@ -35,6 +64,12 @@ export class EditorPage {
       },
       { name },
     );
+  }
+
+  async getProseMirrorMarksJSON(): Promise<unknown[]> {
+    return await this.page.evaluate(() => {
+      return window.pmEditor.getProseMirrorMarksJSON();
+    });
   }
 
   async getProseMirrorSelection(): Promise<{ anchor: number; head: number }> {
@@ -50,5 +85,150 @@ export class EditorPage {
       },
       { index },
     );
+  }
+
+  async getDocJSON(): Promise<object> {
+    return await this.page.evaluate(() => {
+      return window.pmEditor.getDocJSON();
+    });
+  }
+
+  async getCurrentDoc(): Promise<Node> {
+    const schema = createSchema(this.deletionMarksVisibility);
+    const currentDocJSON = await this.getDocJSON();
+    const currentDoc = schema.nodeFromJSON(currentDocJSON);
+    return currentDoc;
+  }
+
+  async getCurrentAndExpectedDoc(expectedDocJSON: object) {
+    const schema = createSchema(this.deletionMarksVisibility);
+    // both docs should be created from the same schema instance,
+    // otherwise the eq assertion from prosemirror-test-builders will be falsy
+    const expectedDoc = schema.nodeFromJSON(expectedDocJSON);
+    const currentDocJSON = await this.getDocJSON();
+    const currentDoc = schema.nodeFromJSON(currentDocJSON);
+    return { currentDoc, expectedDoc };
+  }
+
+  async revertSuggestion(suggestionId: number) {
+    await this.doActionAndWaitForState(() =>
+      this.page.evaluate(
+        ({ suggestionId }) => {
+          window.pmEditor.revertSuggestion(suggestionId);
+        },
+        { suggestionId },
+      ),
+    );
+  }
+
+  async revertAll() {
+    await this.page.getByText("Revert all").click();
+    await this.page.waitForTimeout(100);
+  }
+
+  async applyAll() {
+    await this.page.getByText("Apply all").click();
+    await this.page.waitForTimeout(100);
+  }
+
+  /**
+   * Perform an action and wait for ProseMirror state to update.
+   * Stores the current state reference before pressing, then polls until
+   * editor.view.state is a different object (ProseMirror creates a new
+   * immutable state on every transaction).
+   */
+  private async doActionAndWaitForState(
+    action: () => Promise<void>,
+    opts?: { waitForSelectionChange?: boolean },
+  ): Promise<void> {
+    await this.page.evaluate(() => {
+      const state = window.pmEditor.view.state;
+      window.pmEditor.__prevState = state;
+      window.pmEditor.__prevAnchor = state.selection.anchor;
+      window.pmEditor.__prevHead = state.selection.head;
+    });
+
+    await action();
+
+    if (opts?.waitForSelectionChange) {
+      // Wait for selection to actually change. If a transaction fires but
+      // selection stays the same (e.g., cursor in hidden marks), retry the
+      // keypress until the selection moves.
+      const changed = await this.page
+        .waitForFunction(
+          () => {
+            const state = window.pmEditor.view.state;
+            if (state === window.pmEditor.__prevState) return false;
+            return (
+              state.selection.anchor !== window.pmEditor.__prevAnchor ||
+              state.selection.head !== window.pmEditor.__prevHead
+            );
+          },
+          this.selectors.editor,
+          { timeout: 5000 },
+        )
+        .then(() => true)
+        .catch(() => false);
+
+      if (!changed) {
+        // Selection didn't change — retry
+        return this.doActionAndWaitForState(action, opts);
+      }
+    } else {
+      await this.page.waitForFunction(() => {
+        return window.pmEditor.view.state !== window.pmEditor.__prevState;
+      });
+    }
+  }
+
+  /**
+   * Press a key and wait for ProseMirror state to update.
+   * Stores the current state reference before pressing, then polls until
+   * editor.view.state is a different object (ProseMirror creates a new
+   * immutable state on every transaction).
+   */
+  async pressKey(
+    key: string,
+    opts?: { waitForSelectionChange?: boolean },
+  ): Promise<void> {
+    await this.doActionAndWaitForState(
+      () => this.page.keyboard.press(key),
+      opts,
+    );
+  }
+
+  /**
+   * Insert text and wait for ProseMirror state to update.
+   * Stores the current state reference before pressing, then polls until
+   * editor.view.state is a different object (ProseMirror creates a new
+   * immutable state on every transaction).
+   */
+  async insertText(
+    text: string,
+    opts?: { waitForSelectionChange?: boolean },
+  ): Promise<void> {
+    await this.doActionAndWaitForState(
+      () => this.page.keyboard.insertText(text),
+      opts,
+    );
+  }
+
+  /**
+   * Press a key multiple times, waiting for editor state update after each press.
+   */
+  async pressKeyMultiple(
+    key: string,
+    count: number,
+    opts?: { waitForSelectionChange?: boolean },
+  ): Promise<void> {
+    for (let i = 0; i < count; i++) {
+      await this.pressKey(key, opts);
+    }
+  }
+
+  async setNextNodeId(nextNodeId: number) {
+    await this.page.evaluate((nextNodeId) => {
+      window.pmEditor.setNextNodeId(nextNodeId);
+    }, nextNodeId);
   }
 }

--- a/src/__tests__/replaceStep.test.ts
+++ b/src/__tests__/replaceStep.test.ts
@@ -257,8 +257,8 @@ describe("ReplaceStep", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -599,8 +599,8 @@ describe("ReplaceStep", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -657,8 +657,8 @@ describe("ReplaceStep", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -13,6 +13,15 @@ import { getSuggestionMarks } from "./utils.js";
 import { type SuggestionId } from "./generateId.js";
 import { ZWSP } from "./constants.js";
 import { maybeRevertJoinMark } from "./features/joinOnDelete/index.js";
+import { isJoinMark } from "./features/joinOnDelete/types.js";
+import {
+  revertAllStructureSuggestions,
+  revertStructureSuggestion,
+} from "./features/wrapUnwrap/revert/index.js";
+import {
+  applyAllStructureSuggestions,
+  applyStructureSuggestion,
+} from "./features/wrapUnwrap/apply/index.js";
 
 /**
  * Given a node and a transform, add a set of steps to the
@@ -56,6 +65,7 @@ function applySuggestionsToTransform(
       tr.removeNodeMark(0, markTypeToApply);
     }
   }
+  const restoredStructureSuggestionIds = new Set<SuggestionId>();
 
   node.descendants((child, pos) => {
     if (from !== undefined && pos < from) {
@@ -102,20 +112,91 @@ function applySuggestionsToTransform(
     const insertionTo = insertionFrom + child.nodeSize;
     if (child.isInline) {
       tr.removeMark(insertionFrom, insertionTo, markTypeToApply);
-      const reverted = maybeRevertJoinMark(
+      const joinRevertResult = maybeRevertJoinMark(
         tr,
         insertionFrom,
         insertionTo,
         child,
         markTypeToApply,
       );
-      if (!reverted && child.text === ZWSP) {
+
+      // reverting a join mark may produce new structure marks that were serialized in the join metadata
+      if (joinRevertResult) {
+        joinRevertResult.restoredStructureSuggestionIds.forEach((id) =>
+          restoredStructureSuggestionIds.add(id),
+        );
+      }
+
+      if (!joinRevertResult && child.text === ZWSP) {
         tr.delete(insertionFrom, insertionTo);
       }
     } else {
       tr.removeNodeMark(insertionFrom, markTypeToApply);
     }
     return true;
+  });
+  return {
+    restoredStructureSuggestionIds,
+  };
+}
+
+/**
+ * Collect suggestion IDs of join marks in the node
+ *
+ * @param node
+ * @param deletion
+ * @returns an array of suggestion IDs
+ */
+function findJoinSuggestionIds(node: Node, deletion: MarkType) {
+  const joinSuggestionIds: SuggestionId[] = [];
+
+  node.descendants((child) => {
+    const mark = deletion.isInSet(child.marks);
+    if (!mark || !isJoinMark(mark)) return true;
+    if (!child.isText || child.text !== ZWSP) return true;
+
+    joinSuggestionIds.push(mark.attrs.id);
+    return true;
+  });
+
+  return joinSuggestionIds.reverse();
+}
+
+/**
+ * Revert suggestions revealed by reverting a join mark
+ * Prioritize reverting revealed suggestions with the same id as the join mark
+ * (that means they are linked to the join mark and has to be reverted together as one)
+ * Revert other revealed suggestions as well so the user doesn't have to revert multiple times at the same place
+ *
+ * @param tr
+ * @param suggestionId
+ * @param restoredStructureSuggestionIds
+ */
+function revertRestoredStructureSuggestions(
+  tr: Transform,
+  suggestionId: SuggestionId,
+  restoredStructureSuggestionIds: Set<SuggestionId>,
+) {
+  if (restoredStructureSuggestionIds.has(suggestionId)) {
+    const restoredStructureTransform = revertStructureSuggestion(
+      tr.doc,
+      suggestionId,
+    );
+    restoredStructureTransform.steps.forEach((step) => {
+      tr.step(step);
+    });
+  }
+
+  restoredStructureSuggestionIds.forEach((restoredSuggestionId) => {
+    if (restoredSuggestionId === suggestionId) return;
+
+    const restoredStructureTransform = revertStructureSuggestion(
+      tr.doc,
+      restoredSuggestionId,
+    );
+    restoredStructureTransform.steps.forEach((step) => {
+      tr.step(step);
+    });
   });
 }
 
@@ -230,23 +311,57 @@ function applyModificationsToTransform(
 export function applySuggestionsToNode(node: Node) {
   const { deletion, insertion } = getSuggestionMarks(node.type.schema);
 
-  const transform = new Transform(node);
-  applySuggestionsToTransform(node, transform, insertion, deletion);
-  applyModificationsToTransform(node, transform, 1);
-  return transform.doc;
+  // first, create a structure transform that applies all structure changes on the given node
+  const structureTransform = applyAllStructureSuggestions(node);
+
+  // then start a clear transform from the document where the structure changes are applied
+  const suggestionsTransform = new Transform(structureTransform.doc);
+  applySuggestionsToTransform(
+    suggestionsTransform.doc,
+    suggestionsTransform,
+    insertion,
+    deletion,
+  );
+  applyModificationsToTransform(
+    suggestionsTransform.doc,
+    suggestionsTransform,
+    1,
+  );
+
+  // replay suggestion transform on top of the structure transform
+  suggestionsTransform.steps.forEach((step) => {
+    structureTransform.step(step);
+  });
+
+  const secondStructureTransform = applyAllStructureSuggestions(
+    structureTransform.doc,
+  );
+  secondStructureTransform.steps.forEach((step) => {
+    structureTransform.step(step);
+  });
+
+  return structureTransform.doc;
 }
 
 export function applySuggestionsToRange(doc: Node, from: number, to: number) {
+  const { deletion, insertion } = getSuggestionMarks(doc.type.schema);
+
   // blockRange can only return null if a predicate is provided
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const nodeRange = doc.resolve(from).blockRange(doc.resolve(to))!;
 
-  const { deletion, insertion } = getSuggestionMarks(doc.type.schema);
-
-  const transform = new Transform(doc);
-  applySuggestionsToTransform(
+  // create a structure transform that applies all structure changes on the given node range
+  const structureTransform = applyAllStructureSuggestions(
     doc,
-    transform,
+    nodeRange.start,
+    nodeRange.end,
+  );
+
+  // then start a clear transform from the document where the structure changes are applied
+  const suggestionsTransform = new Transform(structureTransform.doc);
+  applySuggestionsToTransform(
+    suggestionsTransform.doc,
+    suggestionsTransform,
     insertion,
     deletion,
     undefined,
@@ -254,17 +369,31 @@ export function applySuggestionsToRange(doc: Node, from: number, to: number) {
     nodeRange.end,
   );
   applyModificationsToTransform(
-    doc,
-    transform,
+    suggestionsTransform.doc,
+    suggestionsTransform,
     1,
     undefined,
     nodeRange.start,
     nodeRange.end,
   );
 
-  return transform.doc.slice(
-    transform.mapping.map(from),
-    transform.mapping.map(to),
+  // replay suggestion transform on top of the structure transform
+  suggestionsTransform.steps.forEach((step) => {
+    structureTransform.step(step);
+  });
+
+  const secondStructureTransform = applyAllStructureSuggestions(
+    structureTransform.doc,
+    structureTransform.mapping.map(from),
+    structureTransform.mapping.map(to),
+  );
+  secondStructureTransform.steps.forEach((step) => {
+    structureTransform.step(step);
+  });
+
+  return structureTransform.doc.slice(
+    structureTransform.mapping.map(from),
+    structureTransform.mapping.map(to),
   );
 }
 
@@ -281,11 +410,46 @@ export function applySuggestions(
 ) {
   const { deletion, insertion } = getSuggestionMarks(state.schema);
 
-  const tr = state.tr;
-  applySuggestionsToTransform(state.doc, tr, insertion, deletion);
-  applyModificationsToTransform(tr.doc, tr, 1);
-  tr.setMeta(suggestChangesKey, { skip: true });
-  dispatch?.(tr);
+  // create a structure transform that applies all structure changes on the given document
+  const structureTransform = applyAllStructureSuggestions(state.doc);
+
+  // then start a clear transform from the document where the structure changes are applied
+  const suggestionsTransform = new Transform(structureTransform.doc);
+  applySuggestionsToTransform(
+    suggestionsTransform.doc,
+    suggestionsTransform,
+    insertion,
+    deletion,
+  );
+  applyModificationsToTransform(
+    suggestionsTransform.doc,
+    suggestionsTransform,
+    1,
+  );
+
+  // replay suggestion transform on top of the structure transform
+  suggestionsTransform.steps.forEach((step) => {
+    structureTransform.step(step);
+  });
+
+  const secondStructureTransform = applyAllStructureSuggestions(
+    structureTransform.doc,
+  );
+  secondStructureTransform.steps.forEach((step) => {
+    structureTransform.step(step);
+  });
+
+  // apply the structure transform to the transaction
+  const transaction = state.tr;
+  structureTransform.steps.forEach((step) => {
+    transaction.step(step);
+  });
+
+  if (!transaction.steps.length) return false;
+
+  transaction.setMeta(suggestChangesKey, { skip: true });
+  dispatch?.(transaction);
+
   return true;
 }
 
@@ -300,19 +464,58 @@ export function applySuggestionsInRange(from?: number, to?: number): Command {
   return (state, dispatch) => {
     const { deletion, insertion } = getSuggestionMarks(state.schema);
 
-    const tr = state.tr;
-    applySuggestionsToTransform(
+    // create a structure transform that applies all structure changes on the given node range
+    const structureTransform = applyAllStructureSuggestions(
       state.doc,
-      tr,
+      from,
+      to,
+    );
+
+    // then start a clear transform from the document where the structure changes are applied
+    const suggestionsTransform = new Transform(structureTransform.doc);
+    applySuggestionsToTransform(
+      suggestionsTransform.doc,
+      suggestionsTransform,
       insertion,
       deletion,
       undefined,
       from,
       to,
     );
-    applyModificationsToTransform(tr.doc, tr, 1, undefined, from, to);
-    tr.setMeta(suggestChangesKey, { skip: true });
-    dispatch?.(tr);
+    applyModificationsToTransform(
+      suggestionsTransform.doc,
+      suggestionsTransform,
+      1,
+      undefined,
+      from,
+      to,
+    );
+
+    // replay suggestion transform on top of the structure transform
+    suggestionsTransform.steps.forEach((step) => {
+      structureTransform.step(step);
+    });
+
+    const secondStructureTransform = applyAllStructureSuggestions(
+      structureTransform.doc,
+      from === undefined ? undefined : structureTransform.mapping.map(from),
+      to === undefined ? undefined : structureTransform.mapping.map(to),
+    );
+    secondStructureTransform.steps.forEach((step) => {
+      structureTransform.step(step);
+    });
+
+    // apply the structure transform to the transaction
+    const transaction = state.tr;
+    structureTransform.steps.forEach((step) => {
+      transaction.step(step);
+    });
+
+    if (!transaction.steps.length) return false;
+
+    transaction.setMeta(suggestChangesKey, { skip: true });
+    dispatch?.(transaction);
+
     return true;
   };
 }
@@ -332,20 +535,48 @@ export function applySuggestion(
   return (state, dispatch) => {
     const { deletion, insertion } = getSuggestionMarks(state.schema);
 
-    const tr = state.tr;
-    applySuggestionsToTransform(
+    // create a structure transform that applies the given structure change on the given node
+    const structureTransform = applyStructureSuggestion(
       state.doc,
-      tr,
+      suggestionId,
+    );
+
+    // then start a clear transform from the document where the structure changes are applied
+    const suggestionsTransform = new Transform(structureTransform.doc);
+    applySuggestionsToTransform(
+      suggestionsTransform.doc,
+      suggestionsTransform,
       insertion,
       deletion,
       suggestionId,
       from,
       to,
     );
-    applyModificationsToTransform(tr.doc, tr, 1, undefined, from, to);
-    if (!tr.steps.length) return false;
-    tr.setMeta(suggestChangesKey, { skip: true });
-    dispatch?.(tr);
+    applyModificationsToTransform(
+      suggestionsTransform.doc,
+      suggestionsTransform,
+      1,
+      undefined,
+      from,
+      to,
+    );
+
+    // replay suggestion transform on top of the structure transform
+    suggestionsTransform.steps.forEach((step) => {
+      structureTransform.step(step);
+    });
+
+    // apply the structure transform to the transaction
+    const transaction = state.tr;
+    structureTransform.steps.forEach((step) => {
+      transaction.step(step);
+    });
+
+    if (!transaction.steps.length) return false;
+
+    transaction.setMeta(suggestChangesKey, { skip: true });
+    dispatch?.(transaction);
+
     return true;
   };
 }
@@ -362,11 +593,73 @@ export function revertSuggestions(
   dispatch?: EditorView["dispatch"],
 ) {
   const { deletion, insertion } = getSuggestionMarks(state.schema);
-  const tr = state.tr;
-  applySuggestionsToTransform(state.doc, tr, deletion, insertion);
-  applyModificationsToTransform(tr.doc, tr, -1);
-  tr.setMeta(suggestChangesKey, { skip: true });
-  dispatch?.(tr);
+
+  // create a structure transform that reverts all structure changes on the given document
+  const structureTransform = revertAllStructureSuggestions(state.doc);
+
+  // revert all join marks first as well as any structure marks they contain serialized
+  const joinSuggestionIds = findJoinSuggestionIds(
+    structureTransform.doc,
+    deletion,
+  );
+
+  joinSuggestionIds.forEach((suggestionId) => {
+    const suggestionsTransform = new Transform(structureTransform.doc);
+    const { restoredStructureSuggestionIds } = applySuggestionsToTransform(
+      suggestionsTransform.doc,
+      suggestionsTransform,
+      deletion,
+      insertion,
+      suggestionId,
+    );
+
+    suggestionsTransform.steps.forEach((step) => {
+      structureTransform.step(step);
+    });
+
+    revertRestoredStructureSuggestions(
+      structureTransform,
+      suggestionId,
+      restoredStructureSuggestionIds,
+    );
+  });
+
+  // then start a clear transform from the document where the structure changes and join marks are reverted
+  const suggestionsTransform = new Transform(structureTransform.doc);
+  applySuggestionsToTransform(
+    suggestionsTransform.doc,
+    suggestionsTransform,
+    deletion,
+    insertion,
+  );
+  applyModificationsToTransform(
+    suggestionsTransform.doc,
+    suggestionsTransform,
+    -1,
+  );
+  // replay suggestion transform on top of the structure transform
+  suggestionsTransform.steps.forEach((step) => {
+    structureTransform.step(step);
+  });
+
+  const secondStructureTransform = revertAllStructureSuggestions(
+    structureTransform.doc,
+  );
+  secondStructureTransform.steps.forEach((step) => {
+    structureTransform.step(step);
+  });
+
+  // apply the structure transform to the transaction
+  const transaction = state.tr;
+  structureTransform.steps.forEach((step) => {
+    transaction.step(step);
+  });
+
+  if (!transaction.steps.length) return false;
+
+  transaction.setMeta(suggestChangesKey, { skip: true });
+  dispatch?.(transaction);
+
   return true;
 }
 
@@ -380,19 +673,59 @@ export function revertSuggestions(
 export function revertSuggestionsInRange(from?: number, to?: number): Command {
   return (state, dispatch) => {
     const { deletion, insertion } = getSuggestionMarks(state.schema);
-    const tr = state.tr;
-    applySuggestionsToTransform(
+
+    // create a structure transform that reverts all structure changes on the given node range
+    const structureTransform = revertAllStructureSuggestions(
       state.doc,
-      tr,
+      from,
+      to,
+    );
+
+    // then start a clear transform from the document where the structure changes are reverted
+    const suggestionsTransform = new Transform(structureTransform.doc);
+    applySuggestionsToTransform(
+      suggestionsTransform.doc,
+      suggestionsTransform,
       deletion,
       insertion,
       undefined,
       from,
       to,
     );
-    applyModificationsToTransform(tr.doc, tr, -1, undefined, from, to);
-    tr.setMeta(suggestChangesKey, { skip: true });
-    dispatch?.(tr);
+    applyModificationsToTransform(
+      suggestionsTransform.doc,
+      suggestionsTransform,
+      -1,
+      undefined,
+      from,
+      to,
+    );
+
+    // replay suggestion transform on top of the structure transform
+    suggestionsTransform.steps.forEach((step) => {
+      structureTransform.step(step);
+    });
+
+    const secondStructureTransform = revertAllStructureSuggestions(
+      structureTransform.doc,
+      from === undefined ? undefined : structureTransform.mapping.map(from),
+      to === undefined ? undefined : structureTransform.mapping.map(to),
+    );
+    secondStructureTransform.steps.forEach((step) => {
+      structureTransform.step(step);
+    });
+
+    // apply the structure transform to the transaction
+    const transaction = state.tr;
+    structureTransform.steps.forEach((step) => {
+      transaction.step(step);
+    });
+
+    if (!transaction.steps.length) return false;
+
+    transaction.setMeta(suggestChangesKey, { skip: true });
+    dispatch?.(transaction);
+
     return true;
   };
 }
@@ -412,20 +745,56 @@ export function revertSuggestion(
   return (state, dispatch) => {
     const { deletion, insertion } = getSuggestionMarks(state.schema);
 
-    const tr = state.tr;
-    applySuggestionsToTransform(
+    // create a structure transform that reverts the given structure change on the given node
+    const structureTransform = revertStructureSuggestion(
       state.doc,
-      tr,
+      suggestionId,
+    );
+
+    // then start a clear transform from the document where the structure changes are reverted
+    const suggestionsTransform = new Transform(structureTransform.doc);
+    const { restoredStructureSuggestionIds } = applySuggestionsToTransform(
+      suggestionsTransform.doc,
+      suggestionsTransform,
       deletion,
       insertion,
       suggestionId,
       from,
       to,
     );
-    if (!tr.steps.length) return false;
-    tr.setMeta(suggestChangesKey, { skip: true });
-    applyModificationsToTransform(tr.doc, tr, -1, undefined, from, to);
-    dispatch?.(tr);
+    applyModificationsToTransform(
+      suggestionsTransform.doc,
+      suggestionsTransform,
+      -1,
+      undefined,
+      from,
+      to,
+    );
+
+    // replay suggestion transform on top of the structure transform
+    suggestionsTransform.steps.forEach((step) => {
+      structureTransform.step(step);
+    });
+
+    // in case there are structure marks revealed after join mark revert,
+    // revert them as well
+    revertRestoredStructureSuggestions(
+      structureTransform,
+      suggestionId,
+      restoredStructureSuggestionIds,
+    );
+
+    // apply the structure transform to the transaction
+    const transaction = state.tr;
+    structureTransform.steps.forEach((step) => {
+      transaction.step(step);
+    });
+
+    if (!transaction.steps.length) return false;
+
+    transaction.setMeta(suggestChangesKey, { skip: true });
+    dispatch?.(transaction);
+
     return true;
   };
 }

--- a/src/ensureSelectionPlugin.ts
+++ b/src/ensureSelectionPlugin.ts
@@ -105,14 +105,16 @@ export function ensureSelection() {
       });
 
       trace("appendTransaction", "search for new valid $head...");
-      let $newHead = getNewValidPos(
-        newState.selection.$head,
-        getDirection(
-          oldState.selection.$head,
-          newState.selection.$head,
-          pluginState,
-        ),
-      );
+      let $newHead = newState.selection.empty
+        ? $newAnchor
+        : getNewValidPos(
+            newState.selection.$head,
+            getDirection(
+              oldState.selection.$head,
+              newState.selection.$head,
+              pluginState,
+            ),
+          );
       trace("appendTransaction", "new valid $head", $newHead?.pos, {
         $newHead,
       });
@@ -264,9 +266,11 @@ function isPosValid($pos: ResolvedPos) {
   const ZWSP_REGEXP = new RegExp(ZWSP, "g");
   const isZWSPBefore =
     $pos.nodeBefore &&
+    $pos.nodeBefore.isText &&
     $pos.nodeBefore.textContent.replace(ZWSP_REGEXP, "") === "";
   const isZWSPAfter =
     $pos.nodeAfter &&
+    $pos.nodeAfter.isText &&
     $pos.nodeAfter.textContent.replace(ZWSP_REGEXP, "") === "";
 
   if (insertionBefore && insertionAfter && isZWSPBefore && isZWSPAfter) {

--- a/src/features/ensureValidSelection/CONTEXT.md
+++ b/src/features/ensureValidSelection/CONTEXT.md
@@ -1,0 +1,27 @@
+# Ensure Valid Selection
+
+This context covers cursor and text-selection positions that suggestion markers
+make unsafe for normal editing.
+
+## Language
+
+**Valid selection**: A ProseMirror text selection whose anchor and head can be
+used for normal editing without placing the cursor on an **Invalid selection
+position**. _Avoid_: safe cursor, allowed cursor position
+
+**Invalid selection**: A ProseMirror text selection whose anchor or head is not
+safe for normal editing because it is an **Invalid selection position**.
+_Avoid_: bad cursor position, broken selection
+
+**Invalid selection position**: A document position that cannot safely be used
+as a text selection anchor or head because it is outside inline content or would
+break suggestion-marker editing invariants. _Avoid_: bad cursor position, broken
+selection
+
+**Selection correction**: Replacing an invalid text selection with a nearby
+**Valid selection** that preserves the user's visible navigation or editing
+intent. _Avoid_: cursor rescue, selection fixup
+
+**Destination textblock**: The textblock that browser-native selection movement
+has entered before **Selection correction** runs. _Avoid_: same node, target
+node

--- a/src/features/ensureValidSelection/docs/adr/0001-prefer-destination-textblock-for-selection-correction.md
+++ b/src/features/ensureValidSelection/docs/adr/0001-prefer-destination-textblock-for-selection-correction.md
@@ -1,0 +1,15 @@
+# Prefer Destination Textblock For Selection Correction
+
+When browser-native selection movement enters a different textblock but lands on
+an invalid selection position, correct the selection inside that destination
+textblock before falling back to document-direction search. This preserves the
+user's visible navigation intent for tracked empty paragraphs, where the raw
+browser position can be before an insertion-marked zero-width space even though
+the editable position is after it.
+
+The alternative direction-only correction treated upward movement as a leftward
+document-position change and could move the cursor into the previous textblock.
+We also rejected key-specific ArrowUp/ArrowDown handling because mouse clicks
+and platform-native selection movement can produce the same invalid destination
+position, and rejected making that position valid because selection-position
+validity is a separate editing invariant.

--- a/src/features/ensureValidSelection/ensureSelectionPlugin.test.ts
+++ b/src/features/ensureValidSelection/ensureSelectionPlugin.test.ts
@@ -1,0 +1,215 @@
+import { type Node } from "prosemirror-model";
+import { EditorState, NodeSelection, TextSelection } from "prosemirror-state";
+import { assert, describe, it } from "vitest";
+import { ZWSP } from "../../constants.js";
+import { type TaggedNode, testBuilders } from "../../testing/testBuilders.js";
+import { ensureSelection } from "./ensureSelectionPlugin.js";
+
+function createState(doc: Node, selection: TextSelection) {
+  return EditorState.create({
+    doc,
+    selection,
+    plugins: [ensureSelection()],
+  });
+}
+
+function applyTextSelection(state: EditorState, anchor: number, head = anchor) {
+  const selection = TextSelection.create(state.doc, anchor, head);
+  const transaction = state.tr.setSelection(selection);
+  return state.apply(transaction);
+}
+
+function assertTextSelection(
+  state: EditorState,
+  anchor: number,
+  head = anchor,
+) {
+  assert(state.selection instanceof TextSelection);
+  assert.equal(state.selection.anchor, anchor);
+  assert.equal(state.selection.head, head);
+}
+
+function getTag(doc: TaggedNode, tag: string) {
+  const pos = doc.tag[tag];
+  assert(pos !== undefined, `Expected tag "${tag}" to exist`);
+  return pos;
+}
+
+describe("ensureSelection", () => {
+  it("leaves valid text selections unchanged", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph("one<from>"),
+      testBuilders.paragraph("two<to>"),
+    ) as TaggedNode;
+    const state = createState(
+      doc,
+      TextSelection.create(doc, getTag(doc, "from")),
+    );
+
+    const nextState = applyTextSelection(state, getTag(doc, "to"));
+
+    assertTextSelection(nextState, getTag(doc, "to"));
+  });
+
+  it("ignores non-text selections", () => {
+    const doc = testBuilders.doc(
+      testBuilders.image({ src: "https://example.com/image.png" }),
+      testBuilders.paragraph("after<cursor>"),
+    ) as TaggedNode;
+    const state = createState(
+      doc,
+      TextSelection.create(doc, getTag(doc, "cursor")),
+    );
+
+    const nextState = state.apply(
+      state.tr.setSelection(NodeSelection.create(doc, 0)),
+    );
+
+    assert(nextState.selection instanceof NodeSelection);
+    assert.equal(nextState.selection.anchor, 0);
+  });
+
+  it("prefers a valid position in the destination textblock for selection-only movement", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph("Item 2<old>"),
+      testBuilders.paragraph(
+        testBuilders.insertion({ id: 1 }, "<invalid>" + ZWSP + "<valid>"),
+      ),
+      testBuilders.paragraph(testBuilders.insertion({ id: 1 }, ZWSP), "Item 3"),
+    ) as TaggedNode;
+    const state = createState(
+      doc,
+      TextSelection.create(doc, getTag(doc, "old")),
+    );
+
+    const nextState = applyTextSelection(state, getTag(doc, "invalid"));
+
+    assertTextSelection(nextState, getTag(doc, "valid"));
+  });
+
+  it("uses direction fallback when the transaction changes the document", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph("<markStart>A<expected><markEnd>"),
+      testBuilders.paragraph(
+        testBuilders.insertion({ id: 1 }, "<invalid>" + ZWSP + "<sameParent>"),
+      ),
+      testBuilders.paragraph(
+        testBuilders.insertion({ id: 1 }, ZWSP),
+        "<old>Item 3",
+      ),
+    ) as TaggedNode;
+    const state = createState(
+      doc,
+      TextSelection.create(doc, getTag(doc, "old")),
+    );
+
+    const transaction = state.tr;
+    transaction.addMark(
+      getTag(doc, "markStart"),
+      getTag(doc, "markEnd"),
+      testBuilders.schema.marks.strong.create(),
+    );
+    transaction.setSelection(
+      TextSelection.create(transaction.doc, getTag(doc, "invalid")),
+    );
+    const nextState = state.apply(transaction);
+
+    assertTextSelection(nextState, getTag(doc, "expected"));
+  });
+
+  it("uses direction fallback for invalid positions in the same textblock", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "A",
+        testBuilders.deletion({ id: 1 }, "<expected>B<invalid>"),
+        "C<old>",
+      ),
+    ) as TaggedNode;
+    const state = createState(
+      doc,
+      TextSelection.create(doc, getTag(doc, "old")),
+    );
+
+    const nextState = applyTextSelection(state, getTag(doc, "invalid"));
+
+    assertTextSelection(nextState, getTag(doc, "expected"));
+  });
+
+  it("keeps deletion anchor and non-anchor deletion positions continuous", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        testBuilders.deletion(
+          { id: 1, type: "anchor" },
+          "<expected>" + ZWSP + "<invalid>",
+        ),
+        testBuilders.deletion({ id: 1 }, "deleted"),
+        "visible<old>",
+      ),
+    ) as TaggedNode;
+    const state = createState(
+      doc,
+      TextSelection.create(doc, getTag(doc, "old")),
+    );
+
+    const nextState = applyTextSelection(state, getTag(doc, "invalid"));
+
+    assertTextSelection(nextState, getTag(doc, "expected"));
+  });
+
+  it("moves hidden-deletion-style boundary positions to visible content", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph("before<old>"),
+      testBuilders.paragraph(
+        testBuilders.deletion({ id: 1 }, "<invalid>deleted"),
+        "v<expected>isible",
+      ),
+    ) as TaggedNode;
+    const state = createState(
+      doc,
+      TextSelection.create(doc, getTag(doc, "old")),
+    );
+
+    const nextState = applyTextSelection(state, getTag(doc, "invalid"));
+
+    assertTextSelection(nextState, getTag(doc, "expected"));
+  });
+
+  it("keeps paired split marker positions attached to textblock boundaries", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph("before<old>"),
+      testBuilders.paragraph(
+        "content<expected>",
+        testBuilders.insertion({ id: 1 }, ZWSP + "<invalid>"),
+      ),
+    ) as TaggedNode;
+    const state = createState(
+      doc,
+      TextSelection.create(doc, getTag(doc, "old")),
+    );
+
+    const nextState = applyTextSelection(state, getTag(doc, "invalid"));
+
+    assertTextSelection(nextState, getTag(doc, "expected"));
+  });
+
+  it("moves positions between adjacent insertion ZWSPs to a valid neighbor", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "before<old>",
+        testBuilders.insertion(
+          { id: 1 },
+          "<expected>" + ZWSP + "<invalid>" + ZWSP,
+        ),
+        "<valid>after",
+      ),
+    ) as TaggedNode;
+    const state = createState(
+      doc,
+      TextSelection.create(doc, getTag(doc, "old")),
+    );
+
+    const nextState = applyTextSelection(state, getTag(doc, "invalid"));
+
+    assertTextSelection(nextState, getTag(doc, "valid"));
+  });
+});

--- a/src/features/ensureValidSelection/ensureSelectionPlugin.ts
+++ b/src/features/ensureValidSelection/ensureSelectionPlugin.ts
@@ -1,7 +1,6 @@
 import { Plugin, PluginKey, TextSelection } from "prosemirror-state";
-import { getSuggestionMarks } from "./utils.js";
 import { type ResolvedPos } from "prosemirror-model";
-import { ZWSP } from "./constants.js";
+import { getInvalidSelectionPositionReason } from "./selectionPosition.js";
 
 const TRACE_ENABLED = false;
 function trace(...args: unknown[]) {
@@ -73,8 +72,9 @@ export function ensureSelection() {
       },
     },
 
-    appendTransaction(_transactions, oldState, newState) {
+    appendTransaction(transactions, oldState, newState) {
       const pluginState = ensureSelectionKey.getState(newState);
+      const isSelectionOnly = transactions.every((tr) => !tr.docChanged);
 
       if (!(newState.selection instanceof TextSelection)) {
         return null;
@@ -93,12 +93,10 @@ export function ensureSelection() {
 
       trace("appendTransaction", "search for new valid $anchor...");
       let $newAnchor = getNewValidPos(
+        oldState.selection.$anchor,
         newState.selection.$anchor,
-        getDirection(
-          oldState.selection.$anchor,
-          newState.selection.$anchor,
-          pluginState,
-        ),
+        isSelectionOnly,
+        pluginState,
       );
       trace("appendTransaction", "new valid $anchor", $newAnchor?.pos, {
         $newAnchor,
@@ -108,12 +106,10 @@ export function ensureSelection() {
       let $newHead = newState.selection.empty
         ? $newAnchor
         : getNewValidPos(
+            oldState.selection.$head,
             newState.selection.$head,
-            getDirection(
-              oldState.selection.$head,
-              newState.selection.$head,
-              pluginState,
-            ),
+            isSelectionOnly,
+            pluginState,
           );
       trace("appendTransaction", "new valid $head", $newHead?.pos, {
         $newHead,
@@ -169,148 +165,12 @@ export function isEnsureSelectionEnabled() {
 }
 
 function isPosValid($pos: ResolvedPos) {
-  // text selection is only valid in nodes that allow inline content
-  // https://github.com/ProseMirror/prosemirror-state/blob/1.4.4/src/selection.ts#L219
-  if (!$pos.parent.inlineContent) {
-    trace(
-      "isPosValid",
-      $pos.pos,
-      "pos invalid",
-      "reason: not in inlineContent node",
-      {
-        $pos,
-      },
-    );
-    return false;
-  }
+  const invalidReason = getInvalidSelectionPositionReason($pos);
 
-  const { deletion, insertion } = getSuggestionMarks($pos.doc.type.schema);
-
-  const deletionBefore = deletion.isInSet($pos.nodeBefore?.marks ?? []);
-  const deletionAfter = deletion.isInSet($pos.nodeAfter?.marks ?? []);
-
-  const isAnchorBefore =
-    deletionBefore && deletionBefore.attrs["type"] === "anchor";
-  const isAnchorAfter =
-    deletionAfter && deletionAfter.attrs["type"] === "anchor";
-
-  if (isAnchorBefore && deletionAfter && !isAnchorAfter) {
-    trace(
-      "isPosValid",
-      $pos.pos,
-      "pos invalid",
-      "reason: between deletion anchor and non-anchor deletion",
-      { $pos },
-    );
-    return false;
-  }
-
-  if (deletionBefore && deletionAfter && !isAnchorBefore && !isAnchorAfter) {
-    trace(
-      "isPosValid",
-      $pos.pos,
-      "pos invalid",
-      "reason: between two non-anchor deletions",
-      { $pos },
-    );
-    return false;
-  }
-
-  if ($pos.nodeBefore == null && deletionAfter && !isAnchorAfter) {
-    trace(
-      "isPosValid",
-      $pos.pos,
-      "pos invalid",
-      "reason: between node boundary and non-anchor deletion",
-      { $pos },
-    );
-    return false;
-  }
-
-  if (deletionBefore && $pos.nodeAfter == null && !isAnchorBefore) {
-    trace(
-      "isPosValid",
-      $pos.pos,
-      "pos invalid",
-      "reason: between non-anchor deletion and node boundary",
-      { $pos },
-    );
-    return false;
-  }
-
-  if (deletionBefore && !isAnchorBefore && $pos.nodeAfter == null) {
-    trace(
-      "isPosValid",
-      $pos.pos,
-      "pos invalid",
-      "reason: between non-anchor deletion and node boundary",
-      { $pos },
-    );
-    return false;
-  }
-
-  if (deletionBefore && !isAnchorBefore) {
-    trace(
-      "isPosValid",
-      $pos.pos,
-      "pos invalid",
-      "reason: between non-anchor deletion and anything",
-      { $pos },
-    );
-    return false;
-  }
-
-  const insertionBefore = insertion.isInSet($pos.nodeBefore?.marks ?? []);
-  const insertionAfter = insertion.isInSet($pos.nodeAfter?.marks ?? []);
-
-  const ZWSP_REGEXP = new RegExp(ZWSP, "g");
-  const isZWSPBefore =
-    $pos.nodeBefore &&
-    $pos.nodeBefore.isText &&
-    $pos.nodeBefore.textContent.replace(ZWSP_REGEXP, "") === "";
-  const isZWSPAfter =
-    $pos.nodeAfter &&
-    $pos.nodeAfter.isText &&
-    $pos.nodeAfter.textContent.replace(ZWSP_REGEXP, "") === "";
-
-  if (insertionBefore && insertionAfter && isZWSPBefore && isZWSPAfter) {
-    trace(
-      "isPosValid",
-      $pos.pos,
-      "pos invalid",
-      "reason: between two ZWSP insertions",
-      { $pos },
-    );
-    return false;
-  }
-
-  if (
-    insertionBefore &&
-    isZWSPBefore &&
-    $pos.nodeAfter == null &&
-    // a position like this:
-    // <p><insertion>ZWSP</insertion>|</p>
-    // because it means this paragraph was just created and it's empty
-    $pos.parent.textContent.replace(ZWSP_REGEXP, "") !== ""
-  ) {
-    trace(
-      "isPosValid",
-      $pos.pos,
-      "pos invalid",
-      "reason: between ZWSP insertion and right node boundary",
-      { $pos },
-    );
-    return false;
-  }
-
-  if (insertionAfter && isZWSPAfter && $pos.nodeBefore == null) {
-    trace(
-      "isPosValid",
-      $pos.pos,
-      "pos invalid",
-      "reason: between ZWSP insertion and left node boundary",
-      { $pos },
-    );
+  if (invalidReason) {
+    trace("isPosValid", $pos.pos, "pos invalid", `reason: ${invalidReason}`, {
+      $pos,
+    });
     return false;
   }
 
@@ -398,7 +258,55 @@ function findPreviousValidPos($initialPos: ResolvedPos): ResolvedPos | null {
   return isPosValid($pos) ? $pos : null;
 }
 
-function getNewValidPos($pos: ResolvedPos, dir: "left" | "right" | null) {
+function findNearestValidPosInSameParent(
+  $initialPos: ResolvedPos,
+): ResolvedPos | null {
+  if (!$initialPos.parent.inlineContent) return null;
+
+  const start = $initialPos.start();
+  const end = $initialPos.end();
+  const maxDistance = Math.max($initialPos.pos - start, end - $initialPos.pos);
+
+  for (let distance = 0; distance <= maxDistance; distance++) {
+    const nextPos = $initialPos.pos + distance;
+    if (nextPos <= end) {
+      const $nextPos = $initialPos.doc.resolve(nextPos);
+      if (isPosValid($nextPos)) return $nextPos;
+    }
+
+    const prevPos = $initialPos.pos - distance;
+    if (distance > 0 && prevPos >= start) {
+      const $prevPos = $initialPos.doc.resolve(prevPos);
+      if (isPosValid($prevPos)) return $prevPos;
+    }
+  }
+
+  return null;
+}
+
+function getNewValidPosInSelectionDestinationParent(
+  $oldPos: ResolvedPos,
+  $newPos: ResolvedPos,
+): ResolvedPos | null {
+  if (isPosValid($newPos)) return null;
+  if ($oldPos.parent === $newPos.parent) return null;
+  if (!$newPos.parent.inlineContent) return null;
+
+  const $sameParentPos = findNearestValidPosInSameParent($newPos);
+  trace(
+    "getNewValidPosInSelectionDestinationParent",
+    "$sameParentPos",
+    $sameParentPos?.pos,
+    { $oldPos, $newPos, $sameParentPos },
+  );
+
+  return $sameParentPos;
+}
+
+function getNewValidPosByDirection(
+  $pos: ResolvedPos,
+  dir: "left" | "right" | null,
+) {
   if (isPosValid($pos)) return $pos;
 
   trace("getNewValidPos for", $pos.pos, { $pos, dir });
@@ -461,6 +369,25 @@ function getNewValidPos($pos: ResolvedPos, dir: "left" | "right" | null) {
   const prevDist = Math.abs($pos.pos - $prevValidPos.pos);
 
   return nextDist <= prevDist ? $nextValidPos : $prevValidPos;
+}
+
+function getNewValidPos(
+  $oldPos: ResolvedPos,
+  $newPos: ResolvedPos,
+  isSelectionOnly: boolean,
+  pluginState?: PluginState,
+) {
+  const $sameParentPos = isSelectionOnly
+    ? getNewValidPosInSelectionDestinationParent($oldPos, $newPos)
+    : null;
+
+  return (
+    $sameParentPos ??
+    getNewValidPosByDirection(
+      $newPos,
+      getDirection($oldPos, $newPos, pluginState),
+    )
+  );
 }
 
 function getDirection(

--- a/src/features/ensureValidSelection/ensureSelectionPlugin.ts
+++ b/src/features/ensureValidSelection/ensureSelectionPlugin.ts
@@ -10,6 +10,8 @@ function trace(...args: unknown[]) {
 }
 
 interface PluginState {
+  // this is populated on handleKeyDown event
+  // so in appendTransaction we know if one of these keys was pressed
   handleKeyDown: {
     backspace: boolean;
     delete: boolean;
@@ -55,6 +57,9 @@ export function ensureSelection() {
 
         const newState = { ...state };
 
+        // remember if one of the keys we care about was pressed
+        // this is needed for appendTransaction
+
         newState.handleKeyDown.backspace = event.key === "Backspace";
         newState.handleKeyDown.delete = event.key === "Delete";
         newState.handleKeyDown.arrowLeft = event.key === "ArrowLeft";
@@ -84,8 +89,11 @@ export function ensureSelection() {
         isPosValid(newState.selection.$anchor) &&
         isPosValid(newState.selection.$head)
       ) {
+        // both selection positions are valid, no action needed
         return null;
       }
+
+      // find new valid selection anchor and head
 
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (TRACE_ENABLED)
@@ -124,6 +132,8 @@ export function ensureSelection() {
         newSelection.anchor === newState.selection.anchor &&
         newSelection.head === newState.selection.head
       ) {
+        // new selection is the same as old selection, no action needed
+
         trace(
           "appendTransaction",
           "new selection is the same as old selection, skipping",
@@ -180,11 +190,13 @@ function isPosValid($pos: ResolvedPos) {
 function findNextValidPos($initialPos: ResolvedPos): ResolvedPos | null {
   let $pos = $initialPos;
 
-  // to keep searching for the next valid pos we need non-null nodeAfter so we can go right or non-root depth so we can go up
+  // to keep searching for the next valid pos,
+  // we need a non-null nodeAfter so we can go right
+  // or a non-root depth so we can go up
   while (!isPosValid($pos) && ($pos.nodeAfter != null || $pos.depth > 0)) {
     // first check if we can go into nodeAfter
     if ($pos.nodeAfter != null) {
-      // if nodeAfter is inline, we can step into it and search for the valid pos in it
+      // if nodeAfter is inline, we can step into it and search for the valid pos inside
       if ($pos.nodeAfter.isInline) {
         // nodeAfter is inline - move in by one
         $pos = $pos.doc.resolve($pos.pos + 1);
@@ -220,7 +232,9 @@ function findNextValidPos($initialPos: ResolvedPos): ResolvedPos | null {
 function findPreviousValidPos($initialPos: ResolvedPos): ResolvedPos | null {
   let $pos = $initialPos;
 
-  // in order to be able to keep searching, we need either nodeBefore so we can go left, or non-root depth so we can go up
+  // in order to be able to keep searching,
+  // we need either a nodeBefore so we can go left,
+  // or a non-root depth so we can go up
   while (!isPosValid($pos) && ($pos.nodeBefore != null || $pos.depth > 0)) {
     // first check if we can go into nodeBefore
     if ($pos.nodeBefore != null) {
@@ -240,7 +254,7 @@ function findPreviousValidPos($initialPos: ResolvedPos): ResolvedPos | null {
 
         if (localEndPos !== null) {
           // we have a local ending position of the last inline descendant - convert it to global position
-          // move pos to start of node before, add 1 to "enter" nodeBefore, then add local pos
+          // move pos to start of nodeBefore, add 1 to "enter" nodeBefore, then add local pos
           $pos = $pos.doc.resolve(
             $pos.pos - $pos.nodeBefore.nodeSize + 1 + localEndPos,
           );
@@ -258,6 +272,12 @@ function findPreviousValidPos($initialPos: ResolvedPos): ResolvedPos | null {
   return isPosValid($pos) ? $pos : null;
 }
 
+/**
+ * Given a ResolvedPos, find closest valid pos within the same parent
+ *
+ * @param $initialPos
+ * @returns
+ */
 function findNearestValidPosInSameParent(
   $initialPos: ResolvedPos,
 ): ResolvedPos | null {
@@ -265,8 +285,12 @@ function findNearestValidPosInSameParent(
 
   const start = $initialPos.start();
   const end = $initialPos.end();
+
+  // take larger distance - either to the start or to the end of the parent node
   const maxDistance = Math.max($initialPos.pos - start, end - $initialPos.pos);
 
+  // for each distance in range [0, maxDistance],
+  // check if position within that distance from both sides is valid
   for (let distance = 0; distance <= maxDistance; distance++) {
     const nextPos = $initialPos.pos + distance;
     if (nextPos <= end) {
@@ -292,6 +316,9 @@ function getNewValidPosInSelectionDestinationParent(
   if ($oldPos.parent === $newPos.parent) return null;
   if (!$newPos.parent.inlineContent) return null;
 
+  // For selection-only transactions, keep the cursor inside the destination
+  // textblock when possible. Jumping across block boundaries makes arrow-key
+  // navigation feel like it skipped content.
   const $sameParentPos = findNearestValidPosInSameParent($newPos);
   trace(
     "getNewValidPosInSelectionDestinationParent",
@@ -395,6 +422,9 @@ function getDirection(
   $newPos: ResolvedPos,
   pluginState?: PluginState,
 ) {
+  // Position movement does not always reveal user intent. Backspace can leave
+  // the mapped selection at the same or unexpected position after suggestion
+  // markers are inserted, so preserve the keydown direction and search left.
   if (pluginState?.handleKeyDown.backspace) return "left";
 
   if ($newPos.pos > $oldPos.pos) return "right";

--- a/src/features/ensureValidSelection/selectionPosition.ts
+++ b/src/features/ensureValidSelection/selectionPosition.ts
@@ -77,9 +77,9 @@ export function getInvalidSelectionPositionReason(
     insertionBefore &&
     isZWSPBefore &&
     $pos.nodeAfter == null &&
-    // A position like this:
-    // <p><insertion>ZWSP</insertion>|</p>
-    // because it means this paragraph was just created and it's empty.
+    // A trailing inserted ZWSP is invalid only when it is acting as a boundary
+    // marker beside real content. In an otherwise empty paragraph it is the
+    // only editable anchor, so the cursor must be allowed there.
     $pos.parent.textContent.replace(ZWSP_REGEXP, "") !== ""
   ) {
     return "between-zwsp-insertion-and-right-node-boundary";

--- a/src/features/ensureValidSelection/selectionPosition.ts
+++ b/src/features/ensureValidSelection/selectionPosition.ts
@@ -1,0 +1,93 @@
+import { type ResolvedPos } from "prosemirror-model";
+import { ZWSP } from "../../constants.js";
+import { getSuggestionMarks } from "../../utils.js";
+
+export type InvalidSelectionPositionReason =
+  | "not-in-inline-content"
+  | "between-deletion-anchor-and-non-anchor-deletion"
+  | "between-two-non-anchor-deletions"
+  | "between-node-boundary-and-non-anchor-deletion"
+  | "between-non-anchor-deletion-and-node-boundary"
+  | "between-non-anchor-deletion-and-anything"
+  | "between-two-zwsp-insertions"
+  | "between-zwsp-insertion-and-right-node-boundary"
+  | "between-zwsp-insertion-and-left-node-boundary";
+
+export function getInvalidSelectionPositionReason(
+  $pos: ResolvedPos,
+): InvalidSelectionPositionReason | null {
+  // Text selection is only valid in nodes that allow inline content.
+  // https://github.com/ProseMirror/prosemirror-state/blob/1.4.4/src/selection.ts#L219
+  if (!$pos.parent.inlineContent) {
+    return "not-in-inline-content";
+  }
+
+  const { deletion, insertion } = getSuggestionMarks($pos.doc.type.schema);
+
+  const deletionBefore = deletion.isInSet($pos.nodeBefore?.marks ?? []);
+  const deletionAfter = deletion.isInSet($pos.nodeAfter?.marks ?? []);
+
+  const isAnchorBefore =
+    deletionBefore && deletionBefore.attrs["type"] === "anchor";
+  const isAnchorAfter =
+    deletionAfter && deletionAfter.attrs["type"] === "anchor";
+
+  if (isAnchorBefore && deletionAfter && !isAnchorAfter) {
+    return "between-deletion-anchor-and-non-anchor-deletion";
+  }
+
+  if (deletionBefore && deletionAfter && !isAnchorBefore && !isAnchorAfter) {
+    return "between-two-non-anchor-deletions";
+  }
+
+  if ($pos.nodeBefore == null && deletionAfter && !isAnchorAfter) {
+    return "between-node-boundary-and-non-anchor-deletion";
+  }
+
+  if (deletionBefore && $pos.nodeAfter == null && !isAnchorBefore) {
+    return "between-non-anchor-deletion-and-node-boundary";
+  }
+
+  if (deletionBefore && !isAnchorBefore && $pos.nodeAfter == null) {
+    return "between-non-anchor-deletion-and-node-boundary";
+  }
+
+  if (deletionBefore && !isAnchorBefore) {
+    return "between-non-anchor-deletion-and-anything";
+  }
+
+  const insertionBefore = insertion.isInSet($pos.nodeBefore?.marks ?? []);
+  const insertionAfter = insertion.isInSet($pos.nodeAfter?.marks ?? []);
+
+  const ZWSP_REGEXP = new RegExp(ZWSP, "g");
+  const isZWSPBefore =
+    $pos.nodeBefore &&
+    $pos.nodeBefore.isText &&
+    $pos.nodeBefore.textContent.replace(ZWSP_REGEXP, "") === "";
+  const isZWSPAfter =
+    $pos.nodeAfter &&
+    $pos.nodeAfter.isText &&
+    $pos.nodeAfter.textContent.replace(ZWSP_REGEXP, "") === "";
+
+  if (insertionBefore && insertionAfter && isZWSPBefore && isZWSPAfter) {
+    return "between-two-zwsp-insertions";
+  }
+
+  if (
+    insertionBefore &&
+    isZWSPBefore &&
+    $pos.nodeAfter == null &&
+    // A position like this:
+    // <p><insertion>ZWSP</insertion>|</p>
+    // because it means this paragraph was just created and it's empty.
+    $pos.parent.textContent.replace(ZWSP_REGEXP, "") !== ""
+  ) {
+    return "between-zwsp-insertion-and-right-node-boundary";
+  }
+
+  if (insertionAfter && isZWSPAfter && $pos.nodeBefore == null) {
+    return "between-zwsp-insertion-and-left-node-boundary";
+  }
+
+  return null;
+}

--- a/src/features/joinBlocks/__tests__/blockJoin.playwright.test.ts
+++ b/src/features/joinBlocks/__tests__/blockJoin.playwright.test.ts
@@ -13,6 +13,8 @@
  */
 
 import { test, expect } from "../../../__tests__/playwrightBaseTest.js";
+import { eq } from "prosemirror-test-builder";
+import { EditorPage } from "../../../__tests__/playwrightPage.js";
 import {
   testEnterThenBackspace,
   testDoubleEnterDoubleBackspace,
@@ -23,7 +25,6 @@ import {
   pressDelete,
   assertReverted,
   setupDocFromJSON,
-  assertDocFullyReverted,
   performEnterBackspaceCycle,
 } from "../../../__tests__/playwrightHelpers.js";
 
@@ -259,17 +260,18 @@ test.describe("Block Join E2E - Real Keyboard Events", () => {
   });
 
   test.describe("List Item Block Join Behavior", () => {
-    test("Bullet list: Enter then Backspace should rejoin list items", async ({
+    test("Bullet list: Enter then two Backspaces should rejoin list items", async ({
       page,
+      deletionMarksVisibility,
     }) => {
-      const { initialState, initialDoc } = await setupDocFromJSON(page, {
+      const { initialDoc } = await setupDocFromJSON(page, {
         type: "doc",
         content: [
           {
-            type: "bullet_list",
+            type: "bulletList",
             content: [
               {
-                type: "list_item",
+                type: "listItem",
                 content: [
                   {
                     type: "paragraph",
@@ -289,28 +291,26 @@ test.describe("Block Join E2E - Real Keyboard Events", () => {
       });
 
       await page.keyboard.press("Enter");
-      await page.waitForTimeout(100);
-
       await page.keyboard.press("Backspace");
-      await page.waitForTimeout(100);
+      await page.keyboard.press("Backspace");
 
-      const finalState = await page.evaluate(() => window.pmEditor.getState());
-      const finalDoc = await page.evaluate(() => window.pmEditor.getDocJSON());
-
-      assertDocFullyReverted(finalState, finalDoc, initialState, initialDoc);
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+      const docs = await editorPage.getCurrentAndExpectedDoc(initialDoc);
+      expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
     });
 
-    test("Ordered list: Enter then Backspace should rejoin list items", async ({
+    test("Ordered list: Enter then two Backspaces should rejoin list items", async ({
       page,
+      deletionMarksVisibility,
     }) => {
-      const { initialState, initialDoc } = await setupDocFromJSON(page, {
+      const { initialDoc } = await setupDocFromJSON(page, {
         type: "doc",
         content: [
           {
-            type: "ordered_list",
+            type: "orderedList",
             content: [
               {
-                type: "list_item",
+                type: "listItem",
                 content: [
                   {
                     type: "paragraph",
@@ -330,28 +330,26 @@ test.describe("Block Join E2E - Real Keyboard Events", () => {
       });
 
       await page.keyboard.press("Enter");
-      await page.waitForTimeout(100);
-
       await page.keyboard.press("Backspace");
-      await page.waitForTimeout(100);
+      await page.keyboard.press("Backspace");
 
-      const finalState = await page.evaluate(() => window.pmEditor.getState());
-      const finalDoc = await page.evaluate(() => window.pmEditor.getDocJSON());
-
-      assertDocFullyReverted(finalState, finalDoc, initialState, initialDoc);
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+      const docs = await editorPage.getCurrentAndExpectedDoc(initialDoc);
+      expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
     });
 
     test("List item: Enter at middle of text then Backspace", async ({
       page,
+      deletionMarksVisibility,
     }) => {
-      const { initialState, initialDoc } = await setupDocFromJSON(page, {
+      const { initialDoc } = await setupDocFromJSON(page, {
         type: "doc",
         content: [
           {
-            type: "bullet_list",
+            type: "bulletList",
             content: [
               {
-                type: "list_item",
+                type: "listItem",
                 content: [
                   {
                     type: "paragraph",
@@ -387,26 +385,25 @@ test.describe("Block Join E2E - Real Keyboard Events", () => {
       }, splitPosition);
 
       await page.keyboard.press("Enter");
-      await page.waitForTimeout(100);
-
       await page.keyboard.press("Backspace");
-      await page.waitForTimeout(100);
 
-      const finalState = await page.evaluate(() => window.pmEditor.getState());
-      const finalDoc = await page.evaluate(() => window.pmEditor.getDocJSON());
-
-      assertDocFullyReverted(finalState, finalDoc, initialState, initialDoc);
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+      const docs = await editorPage.getCurrentAndExpectedDoc(initialDoc);
+      expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
     });
 
-    test("List item: Multiple sequential splits/joins", async ({ page }) => {
-      const { initialState, initialDoc } = await setupDocFromJSON(page, {
+    test("List item: Multiple sequential splits/joins", async ({
+      page,
+      deletionMarksVisibility,
+    }) => {
+      const { initialDoc } = await setupDocFromJSON(page, {
         type: "doc",
         content: [
           {
-            type: "bullet_list",
+            type: "bulletList",
             content: [
               {
-                type: "list_item",
+                type: "listItem",
                 content: [
                   {
                     type: "paragraph",
@@ -422,32 +419,40 @@ test.describe("Block Join E2E - Real Keyboard Events", () => {
       await page.locator("#editor .ProseMirror").click();
 
       for (let i = 1; i <= 3; i++) {
-        await performEnterBackspaceCycle(page);
+        await page.evaluate(() => {
+          window.pmEditor.setCursorToEnd();
+        });
+        await page.keyboard.press("Enter");
+        await page.keyboard.press("Backspace");
+        await page.keyboard.press("Backspace");
       }
 
-      const finalState = await page.evaluate(() => window.pmEditor.getState());
-      const finalDoc = await page.evaluate(() => window.pmEditor.getDocJSON());
-
-      assertDocFullyReverted(finalState, finalDoc, initialState, initialDoc);
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+      const docs = await editorPage.getCurrentAndExpectedDoc(initialDoc);
+      expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
     });
 
-    test("Deeply nested list (3 levels): Enter then Backspace should rejoin all levels", async ({
+    test("Deeply nested list (3 levels): Enter then two Backspaces should rejoin all levels", async ({
       page,
+      deletionMarksVisibility,
     }) => {
-      const { initialState, initialDoc } = await setupDocFromJSON(page, {
+      const { initialDoc } = await setupDocFromJSON(page, {
         type: "doc",
         content: [
           {
-            type: "bullet_list",
+            type: "bulletList",
             content: [
               {
-                type: "list_item",
+                type: "listItem",
                 content: [
                   {
-                    type: "bullet_list",
+                    type: "paragraph",
+                  },
+                  {
+                    type: "bulletList",
                     content: [
                       {
-                        type: "list_item",
+                        type: "listItem",
                         content: [
                           {
                             type: "paragraph",
@@ -471,37 +476,38 @@ test.describe("Block Join E2E - Real Keyboard Events", () => {
       });
 
       await page.keyboard.press("Enter");
-      await page.waitForTimeout(100);
-
       await page.keyboard.press("Backspace");
-      await page.waitForTimeout(100);
+      await page.keyboard.press("Backspace");
 
-      const finalState = await page.evaluate(() => window.pmEditor.getState());
-      const finalDoc = await page.evaluate(() => window.pmEditor.getDocJSON());
-
-      assertDocFullyReverted(finalState, finalDoc, initialState, initialDoc);
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+      const docs = await editorPage.getCurrentAndExpectedDoc(initialDoc);
+      expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
     });
 
-    test("Extremely nested structure (4 levels): Enter then Backspace should rejoin all levels", async ({
+    test("Extremely nested structure (4 levels): Enter then two Backspaces should rejoin all levels", async ({
       page,
+      deletionMarksVisibility,
     }) => {
-      const { initialState, initialDoc } = await setupDocFromJSON(page, {
+      const { initialDoc } = await setupDocFromJSON(page, {
         type: "doc",
         content: [
           {
             type: "blockquote",
             content: [
               {
-                type: "bullet_list",
+                type: "bulletList",
                 content: [
                   {
-                    type: "list_item",
+                    type: "listItem",
                     content: [
                       {
-                        type: "bullet_list",
+                        type: "paragraph",
+                      },
+                      {
+                        type: "bulletList",
                         content: [
                           {
-                            type: "list_item",
+                            type: "listItem",
                             content: [
                               {
                                 type: "paragraph",
@@ -529,15 +535,12 @@ test.describe("Block Join E2E - Real Keyboard Events", () => {
       });
 
       await page.keyboard.press("Enter");
-      await page.waitForTimeout(100);
-
       await page.keyboard.press("Backspace");
-      await page.waitForTimeout(100);
+      await page.keyboard.press("Backspace");
 
-      const finalState = await page.evaluate(() => window.pmEditor.getState());
-      const finalDoc = await page.evaluate(() => window.pmEditor.getDocJSON());
-
-      assertDocFullyReverted(finalState, finalDoc, initialState, initialDoc);
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+      const docs = await editorPage.getCurrentAndExpectedDoc(initialDoc);
+      expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
     });
   });
 });

--- a/src/features/joinBlocks/__tests__/getZWSPPairsInRange.test.ts
+++ b/src/features/joinBlocks/__tests__/getZWSPPairsInRange.test.ts
@@ -607,7 +607,7 @@ describe("getZWSPPairsInRange", () => {
       assert(result.length === 1, "Expected one pair in list items");
     });
 
-    it("should work with nested structures (list_item > paragraph)", () => {
+    it("should work with nested structures (listItem > paragraph)", () => {
       const doc = testBuilders.doc(
         testBuilders.bulletList(
           testBuilders.listItem(

--- a/src/features/joinBlocks/__tests__/joinBlockBackspace.playwright.test.ts
+++ b/src/features/joinBlocks/__tests__/joinBlockBackspace.playwright.test.ts
@@ -256,6 +256,11 @@ test.describe("Join Block Backspace Bug", () => {
     await page.keyboard.press("Backspace");
     await page.waitForTimeout(50);
 
+    // the ensureSelection plugin will move the cursor to the paragraph below
+    // so get it back up
+    await page.keyboard.press("ArrowUp");
+    await page.waitForTimeout(50);
+
     // one paragraph should be deleted, one should contain contents of both paragraphs in deletion marks
     expect(await editorPage.getParagraphCount()).toBe(7);
     expect(await editorPage.getParagraphText(4)).toBe(

--- a/src/features/joinBlocks/__tests__/playwrightGlobals.d.ts
+++ b/src/features/joinBlocks/__tests__/playwrightGlobals.d.ts
@@ -1,9 +1,13 @@
 import type { EditorView } from "prosemirror-view";
 import type { Mark } from "prosemirror-model";
+import type { SuggestionId } from "../../../generateId.js";
 
 declare global {
   interface Window {
     pmEditor: {
+      __prevState: EditorState;
+      __prevAnchor: number;
+      __prevHead: number;
       view: EditorView;
       getState: () => {
         paragraphCount: number;
@@ -13,7 +17,7 @@ declare global {
         cursorTo: number;
         marks: Mark[];
       };
-      getDocJSON: () => unknown;
+      getDocJSON: () => object;
       getCursorInfo: () => {
         from: number;
         to: number;
@@ -34,9 +38,24 @@ declare global {
       logState: () => void;
       replaceDoc: (doc: unknown) => void;
       getProseMirrorMarkCount: (name: string) => number;
+      getProseMirrorMarksJSON: () => unknown[];
       getProseMirrorSelection: () => { anchor: number; head: number };
-      getTextContentOfChildAtIndex: (index: number) => string;
+      getTextContentOfChildAtIndex: (
+        index: number,
+        childIndexes?: number[],
+      ) => string;
       getDOMTextContentOfChildAtIndex: (index: number) => string;
+      dispatchTransactionWithSteps: (
+        stepJSONs: object[],
+        selection?: { type: string; anchor: number; head: number },
+      ) => void;
+      setSuggestChangesEnabled: (enabled: boolean) => void;
+      revertSuggestion: (
+        suggestionId: SuggestionId,
+        opts?: { structure: boolean },
+      ) => void;
+      revertStructureSuggestion: (suggestionId: SuggestionId) => void;
+      setNextNodeId: (nextNodeId: number) => void;
     };
   }
 }

--- a/src/features/joinBlocks/__tests__/playwrightGlobals.d.ts
+++ b/src/features/joinBlocks/__tests__/playwrightGlobals.d.ts
@@ -25,6 +25,7 @@ declare global {
         parentOffset: number;
         depth: number;
       };
+      setCursorToStart: () => void;
       setCursorToEnd: () => void;
       setCursorToPosition: (pos: number) => void;
       setCursorToEndOfBlock: (blockIndex: number) => void;

--- a/src/features/joinBlocks/index.ts
+++ b/src/features/joinBlocks/index.ts
@@ -49,10 +49,11 @@ export const joinBlocks = (
     const from = ZWSPAtToBoundary.pos;
     insertedRanges.push({ from, to: from + 1 });
   }
+  // Join from the deepest/rightmost boundary first so earlier joins do not
+  // invalidate the recorded positions for later joins and insertion cleanup.
   pairs.reverse();
   insertedRanges.reverse();
 
-  // step 3: join blocks at multiple depths as needed
   for (const p of pairs) {
     const fromPos = p.left?.pos;
     const toPos = p.right?.pos;
@@ -66,7 +67,9 @@ export const joinBlocks = (
     }
   }
 
-  // step 4: remove inserted ranges
+  // Insertion-marked content is accepted by deletion, so it is physically
+  // removed after joins. Map through the join steps because those positions were
+  // collected in the pre-join document.
   const joinSteps = trackedTransaction.steps.slice(startStep);
   const joinMapping = new Mapping(joinSteps.map((s) => s.getMap()));
   for (const range of insertedRanges) {

--- a/src/features/joinBlocks/utils/getZWSPPairsInRange.ts
+++ b/src/features/joinBlocks/utils/getZWSPPairsInRange.ts
@@ -15,7 +15,9 @@ export const getZWSPPairsInRange = (
   const pairs: { left?: ZWSPWithPos; right?: ZWSPWithPos }[] = [];
   let currentEndingZWSP = previousZWSP;
   doc.nodesBetween(from, to, (node, pos, parent, index) => {
-    // two cases: we have a left in currentPair and we're at 0 index
+    // A split block is represented by matching insertion ZWSP anchors at the
+    // end of the left block and the start of the right block. Pair only anchors
+    // with the same suggestion ID so unrelated insertion marks are not joined.
     const insertionMarkId = insertionMarkType.isInSet(node.marks)?.attrs[
       "id"
     ] as SuggestionId | undefined;
@@ -29,16 +31,14 @@ export const getZWSPPairsInRange = (
       // the previousZWSP and the current node's ZWSP are at the same position
       currentEndingZWSP.pos !== pos
     ) {
-      // maybe it's pos + 1
       pairs.push({
         left: currentEndingZWSP,
         right: { pos, node, char: ZWSP, id: insertionMarkId },
       });
-      // don't return yet, we'll have to check if this text node contains
     }
     if (node.isText) {
-      // WE HAVE TO remove ending zwsp anyway. Either we found a pair, on the beginning of the next block
-      // or we did not, but then we don't have a matching pair on a block boundary.
+      // Once real text is encountered, the previous ending anchor can no longer
+      // describe the next block boundary.
       currentEndingZWSP = undefined;
     }
     const lastTextInParent = node.isText && parent?.childCount === index + 1;

--- a/src/features/joinOnDelete/CONTEXT.md
+++ b/src/features/joinOnDelete/CONTEXT.md
@@ -1,0 +1,21 @@
+# Join On Delete Suggestions
+
+This context covers tracked suggestions created when deleting a block boundary
+physically joins accepted content while suggestion mode is enabled.
+
+## Language
+
+**Block join suggestion**: The tracked suggestion concept for a physical block
+join, represented by a deletion-marked zero-width space at the visible text join
+point. Accepting removes the marker and keeps the join. Rejecting removes the
+marker and splits the joined nodes back apart. A **Special transaction shape**
+may group a Block join suggestion with a related Structure suggestion by shared
+suggestion ID. _Avoid_: deletion join marker, join point mark
+
+**Joined node pair**: The left and right nodes at one depth of a physical join,
+serialized in a **Block join suggestion** so rejection can restore their type,
+attrs, and marks. _Avoid_: left/right metadata
+
+**Multi-depth block join**: A physical join that joins more than one node pair
+as one action, such as joining two list items and their paragraphs. The current
+maximum join depth is 2. _Avoid_: TipTap-only join

--- a/src/features/joinOnDelete/README.md
+++ b/src/features/joinOnDelete/README.md
@@ -1,8 +1,0 @@
-When nodes are joined using backspace or delete, let the join happen normally,
-but mark former node boundaries with deletion mark of type="join".
-
-Save information about what nodes were at each side of the boundary before the
-join.
-
-Then on restore, use marks at join points to split the node and restore the node
-markup at each side of the split.

--- a/src/features/joinOnDelete/__tests__/joinOnDelete.playwright.test.ts
+++ b/src/features/joinOnDelete/__tests__/joinOnDelete.playwright.test.ts
@@ -1,14 +1,16 @@
 import { expect, test } from "../../../__tests__/playwrightBaseTest.js";
+import { EditorPage } from "../../../__tests__/playwrightPage.js";
 import { setupDocFromJSON } from "../../../__tests__/playwrightHelpers.js";
 import { ZWSP } from "../../../constants.js";
 import { getSuggestionMarks } from "../../../utils.js";
+import { eq } from "prosemirror-test-builder";
 
 test.describe("Join on Delete E2E - Real Keyboard Events", () => {
   test.describe("Paragraph: Backspace then Enter (after join modification)", () => {
     test("should revert document to original state (join mark is adjacent to split mark)", async ({
       page,
     }) => {
-      const { initialState } = await setupDocFromJSON(page, {
+      await setupDocFromJSON(page, {
         type: "doc",
         content: [
           {
@@ -33,27 +35,35 @@ test.describe("Join on Delete E2E - Real Keyboard Events", () => {
       }
 
       await page.keyboard.press("Backspace");
-      await page.waitForTimeout(50);
 
-      let finalState = await page.evaluate(() => window.pmEditor.getState());
-      expect(finalState.paragraphCount).toBe(1);
+      const editorPage = new EditorPage(page);
+      expect(await editorPage.getParagraphText(0)).toBe(`Hello${ZWSP}World`);
+      expect(await editorPage.getParagraphCount()).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
 
       await page.keyboard.press("Enter");
-      await page.waitForTimeout(50);
 
-      finalState = await page.evaluate(() => window.pmEditor.getState());
-
-      expect(finalState.marks.length).toBe(0);
-      expect(finalState.paragraphCount).toBe(2);
-      expect(finalState.textContent).toBe(initialState.textContent);
-      expect(
-        finalState.cursorFrom,
-        "Cursor is not at the start of the second node after the split",
-      ).toBe(8);
-      expect(
-        finalState.cursorTo,
-        "Cursor is not at the start of the second node after the split",
-      ).toBe(8);
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc({
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-1",
+              },
+              content: [{ type: "text", text: "Hello" }],
+            },
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-4",
+              },
+              content: [{ type: "text", text: "World" }],
+            },
+          ],
+        });
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
     });
 
     test("should NOT revert document to original state (join mark is not adjacent to split mark)", async ({
@@ -86,11 +96,10 @@ test.describe("Join on Delete E2E - Real Keyboard Events", () => {
 
       // join with the previous paragraph
       await page.keyboard.press("Backspace");
-      await page.waitForTimeout(50);
 
-      // verify the paragraphs are joined
-      let finalState = await page.evaluate(() => window.pmEditor.getState());
-      expect(finalState.paragraphCount).toBe(1);
+      const editorPage = new EditorPage(page);
+      expect(await editorPage.getParagraphText(0)).toBe(`Hello${ZWSP}World`);
+      expect(await editorPage.getParagraphCount()).toBe(1);
 
       // type "aaa" (insertion mark)
       // eslint-disable-next-line @typescript-eslint/prefer-for-of
@@ -125,7 +134,7 @@ test.describe("Join on Delete E2E - Real Keyboard Events", () => {
       await page.keyboard.press("Enter");
       await page.waitForTimeout(50);
 
-      finalState = await page.evaluate(() => window.pmEditor.getState());
+      const finalState = await page.evaluate(() => window.pmEditor.getState());
 
       expect(finalState.marks.length).toBe(5);
       expect(finalState.textContent).toBe(`Hello${ZWSP}aaaWor${ZWSP}${ZWSP}ld`);
@@ -157,7 +166,7 @@ test.describe("Join on Delete E2E - Real Keyboard Events", () => {
 
   test.describe("Paragraph: Backspace then Enter (in front of the join modification)", () => {
     test("should revert document to original state", async ({ page }) => {
-      const { initialState } = await setupDocFromJSON(page, {
+      await setupDocFromJSON(page, {
         type: "doc",
         content: [
           {
@@ -182,10 +191,12 @@ test.describe("Join on Delete E2E - Real Keyboard Events", () => {
       }
 
       await page.keyboard.press("Backspace");
-      await page.waitForTimeout(50);
 
-      let finalState = await page.evaluate(() => window.pmEditor.getState());
-      expect(finalState.paragraphCount).toBe(1);
+      const editorPage = new EditorPage(page);
+      expect(await editorPage.getParagraphText(0)).toBe(`Hello${ZWSP}World`);
+      expect(await editorPage.getParagraphCount()).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(0);
 
       // first arrow keypress skips the join mod and goes behind the last letter
       await page.keyboard.press("ArrowLeft");
@@ -198,10 +209,27 @@ test.describe("Join on Delete E2E - Real Keyboard Events", () => {
       await page.keyboard.press("Enter");
       await page.waitForTimeout(50);
 
-      finalState = await page.evaluate(() => window.pmEditor.getState());
-
-      expect(finalState.paragraphCount).toBe(2);
-      expect(finalState.textContent).toBe(initialState.textContent);
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc({
+          type: "doc",
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-1",
+              },
+              content: [{ type: "text", text: "Hello" }],
+            },
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-4",
+              },
+              content: [{ type: "text", text: "World" }],
+            },
+          ],
+        });
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
     });
   });
 
@@ -463,73 +491,6 @@ test.describe("Join on Delete E2E - Real Keyboard Events", () => {
       expect(finalState.marks[1]?.attrs["id"]).toEqual(1);
       expect(finalState.marks[1]?.attrs["type"]).toEqual("join");
       expect(finalState.marks[1]?.type).toEqual(deletion);
-    });
-  });
-
-  test.describe("Lists: join nodes inside lists and list items", () => {
-    test("should revert document to original state after joining two paragraphs inside a list item and then splitting them again", async ({
-      page,
-    }) => {
-      const { initialState } = await setupDocFromJSON(page, {
-        type: "doc",
-        content: [
-          {
-            type: "ordered_list",
-            content: [
-              {
-                type: "list_item",
-                content: [
-                  {
-                    type: "paragraph",
-                    content: [{ type: "text", text: "Hello" }],
-                  },
-                  {
-                    type: "paragraph",
-                    content: [{ type: "text", text: "World" }],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      });
-
-      await page.evaluate(() => {
-        window.pmEditor.setCursorToEnd();
-      });
-
-      let state = await page.evaluate(() => window.pmEditor.getState());
-      expect(state.marks.length).toBe(0);
-      expect(state.textContent).toBe(initialState.textContent);
-
-      await page.keyboard.press("Home");
-      await page.waitForTimeout(50);
-
-      await page.keyboard.press("Backspace");
-      await page.waitForTimeout(50);
-
-      state = await page.evaluate(() => window.pmEditor.getState());
-      expect(state.marks.length).toBe(1);
-      expect(state.textContent).not.toBe(initialState.textContent);
-
-      await page.keyboard.down("Shift");
-      await page.waitForTimeout(50);
-      await page.keyboard.press("Enter");
-      await page.waitForTimeout(50);
-      await page.keyboard.up("Shift");
-      await page.waitForTimeout(50);
-
-      state = await page.evaluate(() => window.pmEditor.getState());
-      expect(state.marks.length).toBe(0);
-      expect(state.textContent).toBe(initialState.textContent);
-      expect(
-        state.cursorFrom,
-        "Cursor is not at the start of the second node after the split",
-      ).toBe(10);
-      expect(
-        state.cursorTo,
-        "Cursor is not at the start of the second node after the split",
-      ).toBe(10);
     });
   });
 });

--- a/src/features/joinOnDelete/__tests__/joinOnDelete.test.ts
+++ b/src/features/joinOnDelete/__tests__/joinOnDelete.test.ts
@@ -12,6 +12,7 @@ import {
   revertSuggestion,
   revertSuggestions,
 } from "../../../commands.js";
+import { joinNodesAndMarkJoinPoints } from "../index.js";
 import {
   type TaggedNode,
   testBuilders,
@@ -27,6 +28,120 @@ function createJoinStep(
 }
 
 describe("handleJoinOnDelete", () => {
+  it("should join without a ZWSP marker when the right node has a Structure add mark", () => {
+    const structureAdd = testBuilders.schema.marks.structure.create({
+      id: 1,
+      data: { op: { op: "add" } },
+    });
+    const baseDoc = testBuilders.doc(
+      testBuilders.paragraph("first<a>"),
+      testBuilders.paragraph("<b>second"),
+    ) as TaggedNode;
+
+    const tagA = baseDoc.tag["a"];
+    const tagB = baseDoc.tag["b"];
+    assert.exists(tagA);
+    assert.exists(tagB);
+
+    const doc = testBuilders.doc(
+      baseDoc.child(0),
+      baseDoc.child(1).mark([structureAdd]),
+    );
+
+    const editorState = EditorState.create({
+      doc,
+      selection: TextSelection.create(doc, tagB),
+    });
+
+    const transform = joinNodesAndMarkJoinPoints(editorState.tr, tagA, tagB, 1);
+
+    const expected = testBuilders.doc(testBuilders.paragraph("firstsecond"));
+
+    assert(
+      eq(transform.doc, expected),
+      `Expected ${transform.doc} to match ${expected}`,
+    );
+  });
+
+  it("should join without a ZWSP marker when the left node has a Structure add mark", () => {
+    const structureAdd = testBuilders.schema.marks.structure.create({
+      id: 1,
+      data: { op: { op: "add" } },
+    });
+    const baseDoc = testBuilders.doc(
+      testBuilders.paragraph("first<a>"),
+      testBuilders.paragraph("<b>second"),
+    ) as TaggedNode;
+
+    const tagA = baseDoc.tag["a"];
+    const tagB = baseDoc.tag["b"];
+    assert.exists(tagA);
+    assert.exists(tagB);
+
+    const doc = testBuilders.doc(
+      baseDoc.child(0).mark([structureAdd]),
+      baseDoc.child(1),
+    );
+
+    const editorState = EditorState.create({
+      doc,
+      selection: TextSelection.create(doc, tagB),
+    });
+
+    const transform = joinNodesAndMarkJoinPoints(editorState.tr, tagA, tagB, 1);
+
+    const expected = testBuilders.doc(
+      testBuilders.paragraph("firstsecond").mark([structureAdd]),
+    );
+
+    assert(
+      eq(transform.doc, expected),
+      `Expected ${transform.doc} to match ${expected}`,
+    );
+  });
+
+  it("should keep adding a ZWSP marker when neither joined node has a Structure add mark", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph("first<a>"),
+      testBuilders.paragraph("<b>second"),
+    ) as TaggedNode;
+
+    const tagA = doc.tag["a"];
+    const tagB = doc.tag["b"];
+    assert.exists(tagA);
+    assert.exists(tagB);
+
+    const editorState = EditorState.create({
+      doc,
+      selection: TextSelection.create(doc, tagB),
+    });
+
+    const transform = joinNodesAndMarkJoinPoints(editorState.tr, tagA, tagB, 1);
+
+    const expected = testBuilders.doc(
+      testBuilders.paragraph(
+        "first",
+        testBuilders.deletion(
+          {
+            id: 1,
+            type: "join",
+            data: {
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+            },
+          },
+          ZWSP,
+        ),
+        "second",
+      ),
+    );
+
+    assert(
+      eq(transform.doc, expected),
+      `Expected ${transform.doc} to match ${expected}`,
+    );
+  });
+
   it("should join two sibling paragraphs with ZWSP marker", () => {
     const doc = testBuilders.doc(
       testBuilders.paragraph("first paragraph<a>"),
@@ -61,8 +176,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -110,8 +225,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 1 }, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 1 }, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -166,8 +281,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 1 }, marks: [] },
-              rightNode: { type: "heading", attrs: { level: 2 }, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 1 }, marks: [] }],
+              rightNodes: [{ type: "heading", attrs: { level: 2 }, marks: [] }],
             },
           },
           ZWSP,
@@ -178,8 +293,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 2 }, marks: [] },
-              rightNode: { type: "heading", attrs: { level: 3 }, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 2 }, marks: [] }],
+              rightNodes: [{ type: "heading", attrs: { level: 3 }, marks: [] }],
             },
           },
           ZWSP,
@@ -190,8 +305,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 3 }, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 3 }, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -202,8 +317,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -214,8 +329,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -226,8 +341,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "heading", attrs: { level: 3 }, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "heading", attrs: { level: 3 }, marks: [] }],
             },
           },
           ZWSP,
@@ -238,8 +353,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 3 }, marks: [] },
-              rightNode: { type: "heading", attrs: { level: 2 }, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 3 }, marks: [] }],
+              rightNodes: [{ type: "heading", attrs: { level: 2 }, marks: [] }],
             },
           },
           ZWSP,
@@ -250,8 +365,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 2 }, marks: [] },
-              rightNode: { type: "heading", attrs: { level: 1 }, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 2 }, marks: [] }],
+              rightNodes: [{ type: "heading", attrs: { level: 1 }, marks: [] }],
             },
           },
           ZWSP,
@@ -267,7 +382,7 @@ describe("handleJoinOnDelete", () => {
     );
   });
 
-  it("should join two list items by deleting node boundary (legacy behaviour)", () => {
+  it("should keep list items separate when deleting only the outer node boundary", () => {
     const doc = testBuilders.doc(
       testBuilders.bulletList(
         testBuilders.listItem(testBuilders.paragraph("first paragraph")),
@@ -303,7 +418,119 @@ describe("handleJoinOnDelete", () => {
     );
   });
 
-  it("should join two list items by deleting a selection across node boundary (legacy behavior)", () => {
+  it("should join two list items and their paragraphs for a multi-depth structural join", () => {
+    const doc = testBuilders.doc(
+      testBuilders.bulletList(
+        testBuilders.listItem(testBuilders.paragraph("first paragraph<a>")),
+        testBuilders.listItem(testBuilders.paragraph("<b>second paragraph")),
+      ),
+    ) as TaggedNode;
+
+    const tagA = doc.tag["a"];
+    const tagB = doc.tag["b"];
+    assert.exists(tagA);
+    assert.exists(tagB);
+
+    const step = createJoinStep(tagA, tagB, true);
+
+    const editorState = EditorState.create({
+      doc,
+    });
+
+    const tr = editorState.tr;
+    suggestReplaceStep(tr, editorState, doc, step, [], 1);
+
+    const newState = editorState.apply(tr);
+
+    const expected = testBuilders.doc(
+      testBuilders.bulletList(
+        testBuilders.listItem(
+          testBuilders.paragraph(
+            "first paragraph",
+            testBuilders.deletion(
+              {
+                id: 1,
+                type: "join",
+                data: {
+                  leftNodes: [
+                    { type: "paragraph", attrs: {}, marks: [] },
+                    { type: "listItem", attrs: {}, marks: [] },
+                  ],
+                  rightNodes: [
+                    { type: "paragraph", attrs: {}, marks: [] },
+                    { type: "listItem", attrs: {}, marks: [] },
+                  ],
+                },
+              },
+              ZWSP,
+            ),
+            "second paragraph",
+          ),
+        ),
+      ),
+    );
+
+    assert(
+      eq(newState.doc, expected),
+      `Expected ${newState.doc} to match ${expected}`,
+    );
+  });
+
+  it("should join two blockquotes and their paragraphs for a multi-depth structural join", () => {
+    const doc = testBuilders.doc(
+      testBuilders.blockquote(testBuilders.paragraph("first paragraph<a>")),
+      testBuilders.blockquote(testBuilders.paragraph("<b>second paragraph")),
+    ) as TaggedNode;
+
+    const tagA = doc.tag["a"];
+    const tagB = doc.tag["b"];
+    assert.exists(tagA);
+    assert.exists(tagB);
+
+    const step = createJoinStep(tagA, tagB, true);
+
+    const editorState = EditorState.create({
+      doc,
+    });
+
+    const tr = editorState.tr;
+    suggestReplaceStep(tr, editorState, doc, step, [], 1);
+
+    const newState = editorState.apply(tr);
+
+    const expected = testBuilders.doc(
+      testBuilders.blockquote(
+        testBuilders.paragraph(
+          "first paragraph",
+          testBuilders.deletion(
+            {
+              id: 1,
+              type: "join",
+              data: {
+                leftNodes: [
+                  { type: "paragraph", attrs: {}, marks: [] },
+                  { type: "blockquote", attrs: {}, marks: [] },
+                ],
+                rightNodes: [
+                  { type: "paragraph", attrs: {}, marks: [] },
+                  { type: "blockquote", attrs: {}, marks: [] },
+                ],
+              },
+            },
+            ZWSP,
+          ),
+          "second paragraph",
+        ),
+      ),
+    );
+
+    assert(
+      eq(newState.doc, expected),
+      `Expected ${newState.doc} to match ${expected}`,
+    );
+  });
+
+  it("should join two list items by deleting a selection across node boundary", () => {
     const doc = testBuilders.doc(
       testBuilders.bulletList(
         testBuilders.listItem(testBuilders.paragraph("first paragr<a>aph")),
@@ -334,10 +561,23 @@ describe("handleJoinOnDelete", () => {
           testBuilders.paragraph(
             "first paragr",
             testBuilders.deletion({ id: 1 }, `aph`),
-          ),
-        ),
-        testBuilders.listItem(
-          testBuilders.paragraph(
+            testBuilders.deletion(
+              {
+                id: 1,
+                type: "join",
+                data: {
+                  leftNodes: [
+                    { type: "paragraph", attrs: {}, marks: [] },
+                    { type: "listItem", attrs: {}, marks: [] },
+                  ],
+                  rightNodes: [
+                    { type: "paragraph", attrs: {}, marks: [] },
+                    { type: "listItem", attrs: {}, marks: [] },
+                  ],
+                },
+              },
+              ZWSP,
+            ),
             testBuilders.deletion({ id: 1 }, `sec`),
             "ond paragraph",
           ),
@@ -387,8 +627,8 @@ describe("handleJoinOnDelete", () => {
                 id: 1,
                 type: "join",
                 data: {
-                  leftNode: { type: "paragraph", attrs: {}, marks: [] },
-                  rightNode: { type: "paragraph", attrs: {}, marks: [] },
+                  leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+                  rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
                 },
               },
               ZWSP,
@@ -435,8 +675,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -482,8 +722,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -527,8 +767,8 @@ describe("handleJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -554,8 +794,8 @@ describe("applyJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
             newValue: null,
           },
@@ -594,8 +834,8 @@ describe("applyJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 1 }, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 1 }, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -609,8 +849,8 @@ describe("applyJoinOnDelete", () => {
             id: 2,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -624,8 +864,8 @@ describe("applyJoinOnDelete", () => {
             id: 3,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "heading", attrs: { level: 2 }, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "heading", attrs: { level: 2 }, marks: [] }],
             },
           },
           ZWSP,
@@ -666,6 +906,47 @@ describe("revertJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+            },
+          },
+          ZWSP,
+        ),
+        "second paragraph",
+      ),
+    );
+
+    const editorState = EditorState.create({
+      doc,
+      selection: TextSelection.atStart(doc),
+    });
+
+    const newState = await new Promise<EditorState>((resolve) => {
+      revertSuggestions(editorState, (tr) => {
+        resolve(editorState.apply(tr));
+      });
+    });
+
+    const expected = testBuilders.doc(
+      testBuilders.paragraph("first paragraph"),
+      testBuilders.paragraph("second paragraph"),
+    );
+
+    assert(
+      eq(newState.doc, expected),
+      `Expected ${newState.doc} to match ${expected}`,
+    );
+  });
+
+  it("should revert legacy paragraph join metadata back to two paragraphs", async () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "first paragraph",
+        testBuilders.deletion(
+          {
+            id: 1,
+            type: "join",
+            data: {
               leftNode: { type: "paragraph", attrs: {}, marks: [] },
               rightNode: { type: "paragraph", attrs: {}, marks: [] },
             },
@@ -698,6 +979,58 @@ describe("revertJoinOnDelete", () => {
     );
   });
 
+  it("should reject over-max join metadata and remove the invalid join marker", async () => {
+    const doc = testBuilders.doc(
+      testBuilders.blockquote(
+        testBuilders.paragraph(
+          "first paragraph",
+          testBuilders.deletion(
+            {
+              id: 1,
+              type: "join",
+              data: {
+                leftNodes: [
+                  { type: "paragraph", attrs: {}, marks: [] },
+                  { type: "blockquote", attrs: {}, marks: [] },
+                  { type: "blockquote", attrs: {}, marks: [] },
+                ],
+                rightNodes: [
+                  { type: "paragraph", attrs: {}, marks: [] },
+                  { type: "blockquote", attrs: {}, marks: [] },
+                  { type: "blockquote", attrs: {}, marks: [] },
+                ],
+              },
+            },
+            ZWSP,
+          ),
+          "second paragraph",
+        ),
+      ),
+    );
+
+    const editorState = EditorState.create({
+      doc,
+      selection: TextSelection.atStart(doc),
+    });
+
+    const newState = await new Promise<EditorState>((resolve) => {
+      revertSuggestion(1)(editorState, (tr) => {
+        resolve(editorState.apply(tr));
+      });
+    });
+
+    const expected = testBuilders.doc(
+      testBuilders.blockquote(
+        testBuilders.paragraph("first paragraphsecond paragraph"),
+      ),
+    );
+
+    assert(
+      eq(newState.doc, expected),
+      `Expected ${newState.doc} to match ${expected}`,
+    );
+  });
+
   it("should revert heading-paragraph join back to heading and paragraph", async () => {
     // Start with a joined heading containing ZWSP with join mark
     const doc = testBuilders.doc(
@@ -709,8 +1042,8 @@ describe("revertJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 1 }, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 1 }, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -752,8 +1085,8 @@ describe("revertJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 1 }, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 1 }, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -767,8 +1100,8 @@ describe("revertJoinOnDelete", () => {
             id: 2,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -782,8 +1115,8 @@ describe("revertJoinOnDelete", () => {
             id: 3,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "heading", attrs: { level: 2 }, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "heading", attrs: { level: 2 }, marks: [] }],
             },
           },
           ZWSP,
@@ -826,8 +1159,8 @@ describe("revertJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 1 }, marks: [] },
-              rightNode: { type: "heading", attrs: { level: 2 }, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 1 }, marks: [] }],
+              rightNodes: [{ type: "heading", attrs: { level: 2 }, marks: [] }],
             },
           },
           ZWSP,
@@ -838,8 +1171,8 @@ describe("revertJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 2 }, marks: [] },
-              rightNode: { type: "heading", attrs: { level: 3 }, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 2 }, marks: [] }],
+              rightNodes: [{ type: "heading", attrs: { level: 3 }, marks: [] }],
             },
           },
           ZWSP,
@@ -850,8 +1183,8 @@ describe("revertJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 3 }, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 3 }, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -862,8 +1195,8 @@ describe("revertJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -874,8 +1207,8 @@ describe("revertJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -886,8 +1219,8 @@ describe("revertJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "heading", attrs: { level: 3 }, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "heading", attrs: { level: 3 }, marks: [] }],
             },
           },
           ZWSP,
@@ -898,8 +1231,8 @@ describe("revertJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 3 }, marks: [] },
-              rightNode: { type: "heading", attrs: { level: 2 }, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 3 }, marks: [] }],
+              rightNodes: [{ type: "heading", attrs: { level: 2 }, marks: [] }],
             },
           },
           ZWSP,
@@ -910,8 +1243,8 @@ describe("revertJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "heading", attrs: { level: 2 }, marks: [] },
-              rightNode: { type: "heading", attrs: { level: 1 }, marks: [] },
+              leftNodes: [{ type: "heading", attrs: { level: 2 }, marks: [] }],
+              rightNodes: [{ type: "heading", attrs: { level: 1 }, marks: [] }],
             },
           },
           ZWSP,
@@ -957,8 +1290,8 @@ describe("revertJoinOnDelete", () => {
             id: 1,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -969,8 +1302,8 @@ describe("revertJoinOnDelete", () => {
             id: 2,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,
@@ -997,8 +1330,8 @@ describe("revertJoinOnDelete", () => {
             id: 2,
             type: "join",
             data: {
-              leftNode: { type: "paragraph", attrs: {}, marks: [] },
-              rightNode: { type: "paragraph", attrs: {}, marks: [] },
+              leftNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
+              rightNodes: [{ type: "paragraph", attrs: {}, marks: [] }],
             },
           },
           ZWSP,

--- a/src/features/joinOnDelete/__tests__/joinOnDeleteInLists.playwright.test.ts
+++ b/src/features/joinOnDelete/__tests__/joinOnDeleteInLists.playwright.test.ts
@@ -1,0 +1,393 @@
+import { expect, test } from "../../../__tests__/playwrightBaseTest.js";
+import { EditorPage } from "../../../__tests__/playwrightPage.js";
+import { setupDocFromJSON } from "../../../__tests__/playwrightHelpers.js";
+import { eq } from "prosemirror-test-builder";
+
+test.describe("Join on Delete E2E - Real Keyboard Events", () => {
+  test.describe("Lists: join nodes inside lists and list items", () => {
+    test("should revert document to original state after joining two paragraphs inside a list item and then splitting them again", async ({
+      page,
+    }) => {
+      const { initialState } = await setupDocFromJSON(page, {
+        type: "doc",
+        content: [
+          {
+            type: "orderedList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Hello" }],
+                  },
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "World" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      await page.evaluate(() => {
+        window.pmEditor.setCursorToEnd();
+      });
+
+      let state = await page.evaluate(() => window.pmEditor.getState());
+      expect(state.marks.length).toBe(0);
+      expect(state.textContent).toBe(initialState.textContent);
+
+      await page.keyboard.press("Home");
+      await page.waitForTimeout(50);
+
+      await page.keyboard.press("Backspace");
+      await page.waitForTimeout(50);
+
+      state = await page.evaluate(() => window.pmEditor.getState());
+      expect(state.marks.length).toBe(1);
+      expect(state.textContent).not.toBe(initialState.textContent);
+
+      await page.keyboard.down("Shift");
+      await page.waitForTimeout(50);
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(50);
+      await page.keyboard.up("Shift");
+      await page.waitForTimeout(50);
+
+      state = await page.evaluate(() => window.pmEditor.getState());
+      expect(state.marks.length).toBe(0);
+      expect(state.textContent).toBe(initialState.textContent);
+      expect(
+        state.cursorFrom,
+        "Cursor is not at the start of the second node after the split",
+      ).toBe(10);
+      expect(
+        state.cursorTo,
+        "Cursor is not at the start of the second node after the split",
+      ).toBe(10);
+    });
+
+    test("should revert after pressing backspace multiple times at the start of list items, joining them into one", async ({
+      page,
+      deletionMarksVisibility,
+    }) => {
+      const { initialDoc } = await setupDocFromJSON(page, {
+        type: "doc",
+        content: [
+          {
+            type: "orderedList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Item 1" }],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Item 2" }],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Item 3" }],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Item 4" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      await page.evaluate(() => {
+        window.pmEditor.setCursorToEnd();
+      });
+
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+      // move to start of list item Item 4
+      await editorPage.pressKey("Home");
+      // join list item Item 4 with list item Item 3,
+      // paragraph Item 4 will be placed next to paragraph Item 3 (2 paragraphs in one list item)
+      await editorPage.pressKey("Backspace");
+
+      // we should have 1 structure mark that represents a move of paragraph Item 4 into a list item Item 3
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+
+      // join paragraph Item 4 with the paragraph Item 3
+      // paragraph Item 4 will be joined with paragraph Item 3 so the list item will have one paragraph Item 3Item 4
+      await editorPage.pressKey("Backspace");
+
+      // we should have a single deletion mark (join marker) that holds the information about the structure mark in it's rightNode data
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+      // move to start of list item Item 3Item 4
+      await editorPage.pressKey("Home");
+      // join list item Item 3Item 4 with list item Item 2,
+      // paragraph Item 3Item 4 will be placed next to paragraph Item 2 (2 paragraphs in one list item)
+      await editorPage.pressKey("Backspace");
+
+      // we should have 1 structure mark that represents a move of paragraph Item 3Item 4 into a list item Item 2
+      // and one deletion mark (join marker) from the previous step
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+      // join paragraph Item 3Item 4 with the paragraph Item 2
+      // paragraph Item 3Item 4 will be joined with paragraph Item 2 so the list item will have one paragraph Item 2Item 3Item 4
+      await editorPage.pressKey("Backspace");
+
+      // we should have two deletion marks (join markers) that hold information about the structure marks in its rightNode data
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(2);
+
+      // the bug is as follows
+      // on revertAll, first we revert all structure marks
+      // but no structure marks are currently present
+      // so we revert all normal marks (join markers)
+      // first we revert the last join
+      // it reverts into left and right node, where right node holds a restored structure mark from the join marker metadata
+      // then we revert the second to last join
+      // it also reverts into left and right node
+      // however at the moment of revert, the node on the right holds a structure marks
+      // and the join metadata of the left node doesn't have any marks (because when this join marker was created, left node didn't have any marks)
+      // so when we revert the second to last join marker, node on the left loses its structure mark, so revert to initial state becomes impossible
+
+      await editorPage.revertAll();
+
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc(initialDoc);
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
+    });
+
+    test("should automatically revert a later structure suggestion when rejecting a join restores an older dependent structure suggestion", async ({
+      page,
+      deletionMarksVisibility,
+    }) => {
+      const { initialDoc } = await setupDocFromJSON(page, {
+        type: "doc",
+        content: [
+          {
+            type: "orderedList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Item 1" }],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Item 2" }],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Item 3" }],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Item 4" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      await page.evaluate(() => {
+        window.pmEditor.setCursorToEnd();
+      });
+
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+      // move to start of list item Item 4
+      await editorPage.pressKey("Home");
+      // join list item Item 4 with list item Item 3,
+      // paragraph Item 4 will be placed next to paragraph Item 3 (2 paragraphs in one list item)
+      await editorPage.pressKey("Backspace");
+
+      // we should have 1 structure mark that represents a move of paragraph Item 4 into a list item Item 3
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+
+      // join paragraph Item 4 with the paragraph Item 3
+      // paragraph Item 4 will be joined with paragraph Item 3 so the list item will have one paragraph Item 3Item 4
+      await editorPage.pressKey("Backspace");
+
+      // we should have a single deletion mark (join marker) that holds the information about the structure mark in it's rightNode data
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+      // move to start of list item Item 3Item 4
+      await editorPage.pressKey("Home");
+      // join list item Item 3Item 4 with list item Item 2,
+      // paragraph Item 3Item 4 will be placed next to paragraph Item 2 (2 paragraphs in one list item)
+      await editorPage.pressKey("Backspace");
+
+      // we should have 1 structure mark that represents a move of paragraph Item 3Item 4 into a list item Item 2
+      // and one deletion mark (join marker) from the previous step
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+      // revert only the join mark
+      await editorPage.revertSuggestion(2);
+
+      // what should happen is that join mark reversal will deserialize an old structure mark (id=1)
+      // that will also be automatically reverted
+      // but structure mark reversal will detect that later structure mark (id=3) needs to be reverted as well
+      // so both structure moves and the selected join are reverted, returning to the original document.”
+
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc(initialDoc);
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
+    });
+
+    test("should revert after pressing backspace multiple times across multiple list items, deleting content and joining them into one", async ({
+      page,
+      deletionMarksVisibility,
+    }) => {
+      const { initialDoc } = await setupDocFromJSON(page, {
+        type: "doc",
+        content: [
+          {
+            type: "orderedList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Item 1" }],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Item 2" }],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Item 3" }],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Item 4" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      await page.evaluate(() => {
+        window.pmEditor.setCursorToEnd();
+      });
+
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+      // use backspace to delete "Item 4" and press it one more time to join with the above list item Item 3
+      await editorPage.pressKeyMultiple("Backspace", "Item 4".length);
+      await editorPage.pressKey("Backspace");
+
+      // we should have 2 deletion marks (one "anchor", one deleted "Item 4") and one structure mark
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(2);
+
+      // join paragraph Item 4 with paragraph Item 3 in one list item
+      await editorPage.pressKey("Backspace");
+
+      // we should have 2 deletion marks (one join marker, one deleted "Item 4") and no structure mark (swallowed by the join marker)
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(2);
+
+      // use backspace to delete "Item 3" and press it one more time to join with the above list item Item 2
+      await editorPage.pressKeyMultiple("Backspace", "Item 3".length);
+      await editorPage.pressKey("Backspace");
+
+      // we should have 4 deletion marks (one "anchor", one join marker, two deletions "Item 4" and "Item 3")
+      // and one structure mark (the move of paragraph Item 3 into a list item Item 2)
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(4);
+
+      // join paragraph Item 3 with paragraph Item 2 in one list item
+      await editorPage.pressKey("Backspace");
+
+      // we should have 4 deletion marks (two join markers, two deletions "Item 4" and "Item 3")
+      // and no structure mark (swallowed by the join marker)
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(4);
+
+      // use backspace to delete "Item 2"
+      await editorPage.pressKeyMultiple("Backspace", "Item 2".length);
+
+      // we should have 6 deletion marks (one "anchor", two join markers, three deletions "Item 4", "Item 3" and "Item 2")
+      // and no structure marks
+      // (all structure marks were swallowed by the join markers and exist in their metadata)
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(6);
+
+      await editorPage.revertAll();
+
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc(initialDoc);
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
+    });
+  });
+});

--- a/src/features/joinOnDelete/__tests__/joinOnDeleteInListsTipTapStyle.playwright.test.ts
+++ b/src/features/joinOnDelete/__tests__/joinOnDeleteInListsTipTapStyle.playwright.test.ts
@@ -1007,7 +1007,7 @@ test.describe("Join on Delete E2E - Real Keyboard Events", () => {
       });
 
       // put the cursor to the start of the paragraph
-      await editorPage.pressKey("Home", { waitForSelectionChange: true });
+      await editorPage.pressKey("Home");
 
       // join the paragraph into the last list item
       await dispatchTipTapNewParagraphIntoListStep(page);
@@ -1028,7 +1028,7 @@ test.describe("Join on Delete E2E - Real Keyboard Events", () => {
       expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(1);
 
       // verify cursor position by entering text
-      await editorPage.insertText("FOO", { waitForSelectionChange: true });
+      await editorPage.insertText("FOO");
       await expect(editorPage.getParagraphAt(3)).toHaveText(
         "Item 4FOOsample paragraph",
       );
@@ -1097,7 +1097,7 @@ test.describe("Join on Delete E2E - Real Keyboard Events", () => {
       expect(joinMarks).toHaveLength(0);
 
       // verify cursor position by entering text
-      await editorPage.insertText("FOO", { waitForSelectionChange: true });
+      await editorPage.insertText("FOO");
       await expect(editorPage.getParagraphAt(3)).toHaveText(
         "Item 4FOOsample paragraph",
       );

--- a/src/features/joinOnDelete/__tests__/joinOnDeleteInListsTipTapStyle.playwright.test.ts
+++ b/src/features/joinOnDelete/__tests__/joinOnDeleteInListsTipTapStyle.playwright.test.ts
@@ -1,0 +1,1106 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../../../__tests__/playwrightBaseTest.js";
+import { EditorPage } from "../../../__tests__/playwrightPage.js";
+import { setupDocFromJSON } from "../../../__tests__/playwrightHelpers.js";
+import { ZWSP } from "../../../constants.js";
+import { eq } from "prosemirror-test-builder";
+import { isJoinMarkObject } from "../types.js";
+
+// join two list items like TipTap does:
+// from the beginning of a list item, backspace joins both the list item and the paragraph inside with the list item above
+// so the result of the join is a single list item with a single paragraph that has joined content inside
+// (by default, prosemirror joins the list items but not the paragraphs
+// so the result is a single list item with two paragraphs)
+const TIPTAP_DEPTH_TWO_JOIN_STEP = {
+  stepType: "replace",
+  from: 19,
+  to: 23,
+  structure: true,
+};
+
+const TIPTAP_DEPTH_TWO_JOIN_DOC = {
+  type: "doc",
+  content: [
+    {
+      type: "orderedList",
+      content: [
+        {
+          type: "listItem",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Item 0" }],
+            },
+          ],
+        },
+        {
+          type: "listItem",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Item 1" }],
+            },
+          ],
+        },
+        {
+          type: "listItem",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Item 2" }],
+            },
+          ],
+        },
+        {
+          type: "listItem",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Item 3" }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+// in a situation where we have a list, and a paragraph below the list
+// and we are at the beginning of the paragraph, and we press backspace
+// raw ProseMirror joins the paragraph with the list, but not with the last list item,
+// so the paragraph becomes the new last list item
+// in raw ProseMirror you get <li><p>LastListItem</p></li><li><p>ParagraphText</p></li>
+// TipTap additionally joins the paragraph with the last list item
+// so in TipTap you get <li><p>LastListItemParagraphText</p></li>
+// this is the steps that are produced by TipTap for the given document in this situation
+const TIPTAP_PARAGRAPH_INTO_LIST_STEPS = [
+  { stepType: "replace", from: 42, to: 60 },
+  {
+    stepType: "replace",
+    from: 40,
+    to: 40,
+    slice: {
+      content: [
+        {
+          type: "paragraph",
+          attrs: { id: "node-9", textAlign: null },
+          content: [{ type: "text", text: "sample paragraph" }],
+        },
+      ],
+    },
+  },
+  { stepType: "replace", from: 39, to: 41, structure: true },
+];
+
+const TIPTAP_PARAGRAPH_INTO_LIST_SELECTION = {
+  type: "text",
+  anchor: 39,
+  head: 39,
+};
+
+const TIPTAP_PARAGRAPH_INTO_LIST_DOC = {
+  type: "doc",
+  content: [
+    {
+      type: "orderedList",
+      attrs: {
+        order: 1,
+        id: "node-0",
+      },
+      content: [
+        {
+          type: "listItem",
+          attrs: {
+            id: "node-1",
+          },
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-2",
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Item 1",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "listItem",
+          attrs: {
+            id: "node-3",
+          },
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-4",
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Item 2",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "listItem",
+          attrs: {
+            id: "node-5",
+          },
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-6",
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Item 3",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "listItem",
+          attrs: {
+            id: "node-7",
+          },
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-8",
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Item 4",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: "paragraph",
+      attrs: {
+        id: "node-9",
+      },
+      content: [
+        {
+          type: "text",
+          text: "sample paragraph",
+        },
+      ],
+    },
+  ],
+};
+
+// same situation as above, but the paragraph below and it's content were added with track changes on,
+// so the paragraph has a structure mark, and it's content is an insertion mark
+const TIPTAP_NEW_PARAGRAPH_INTO_LIST_STEPS = [
+  { stepType: "replace", from: 42, to: 60 },
+  {
+    stepType: "replace",
+    from: 40,
+    to: 40,
+    slice: {
+      content: [
+        {
+          type: "paragraph",
+          attrs: { id: "node-10", textAlign: null },
+          content: [
+            {
+              type: "text",
+              marks: [{ type: "insertion", attrs: { id: "2" } }],
+              text: "sample paragraph",
+            },
+          ],
+          marks: [
+            {
+              type: "structure",
+              attrs: { id: "1", data: { op: { op: "add" } } },
+            },
+          ],
+        },
+      ],
+    },
+  },
+  { stepType: "replace", from: 39, to: 41, structure: true },
+];
+
+const TIPTAP_NEW_PARAGRAPH_INTO_LIST_SELECTION = {
+  type: "text",
+  anchor: 39,
+  head: 39,
+};
+
+const TIPTAP_NEW_PARAGRAPH_INTO_LIST_DOC = {
+  type: "doc",
+  content: [
+    {
+      type: "orderedList",
+      attrs: {
+        order: 1,
+        id: "node-0",
+      },
+      content: [
+        {
+          type: "listItem",
+          attrs: {
+            id: "node-1",
+          },
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-2",
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Item 1",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "listItem",
+          attrs: {
+            id: "node-3",
+          },
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-4",
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Item 2",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "listItem",
+          attrs: {
+            id: "node-5",
+          },
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-6",
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Item 3",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "listItem",
+          attrs: {
+            id: "node-7",
+          },
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-8",
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Item 4",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+async function dispatchTipTapDepthTwoJoinStep(page: Page) {
+  await page.evaluate((step) => {
+    window.pmEditor.dispatchTransactionWithSteps([step]);
+  }, TIPTAP_DEPTH_TWO_JOIN_STEP);
+}
+
+async function dispatchTipTapParagraphIntoListStep(page: Page) {
+  await page.evaluate(
+    ({ steps, selection }) => {
+      window.pmEditor.dispatchTransactionWithSteps(steps, selection);
+    },
+    {
+      steps: TIPTAP_PARAGRAPH_INTO_LIST_STEPS,
+      selection: TIPTAP_PARAGRAPH_INTO_LIST_SELECTION,
+    },
+  );
+}
+
+async function dispatchTipTapNewParagraphIntoListStep(page: Page) {
+  await page.evaluate(
+    ({ steps, selection }) => {
+      window.pmEditor.dispatchTransactionWithSteps(steps, selection);
+    },
+    {
+      steps: TIPTAP_NEW_PARAGRAPH_INTO_LIST_STEPS,
+      selection: TIPTAP_NEW_PARAGRAPH_INTO_LIST_SELECTION,
+    },
+  );
+}
+
+test.describe("Join on Delete E2E - Real Keyboard Events", () => {
+  test.describe("TipTap-style multi-depth list item join step", () => {
+    test("joins list items when suggestions are disabled", async ({ page }) => {
+      await setupDocFromJSON(page, TIPTAP_DEPTH_TWO_JOIN_DOC);
+      await page.evaluate(() => {
+        window.pmEditor.setSuggestChangesEnabled(false);
+      });
+
+      await dispatchTipTapDepthTwoJoinStep(page);
+
+      const editorPage = new EditorPage(page);
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc({
+          type: "doc",
+          content: [
+            {
+              type: "orderedList",
+              attrs: {
+                id: "node-1",
+              },
+              content: [
+                {
+                  type: "listItem",
+                  attrs: {
+                    id: "node-2",
+                  },
+                  content: [
+                    {
+                      type: "paragraph",
+                      attrs: {
+                        id: "node-3",
+                      },
+                      content: [{ type: "text", text: "Item 0" }],
+                    },
+                  ],
+                },
+                {
+                  type: "listItem",
+                  attrs: {
+                    id: "node-4",
+                  },
+                  content: [
+                    {
+                      type: "paragraph",
+                      attrs: {
+                        id: "node-5",
+                      },
+                      content: [{ type: "text", text: "Item 1Item 2" }],
+                    },
+                  ],
+                },
+                {
+                  type: "listItem",
+                  attrs: {
+                    id: "node-8",
+                  },
+                  content: [
+                    {
+                      type: "paragraph",
+                      attrs: {
+                        id: "node-9",
+                      },
+                      content: [{ type: "text", text: "Item 3" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        });
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
+    });
+
+    test("creates one block join suggestion and reverts it", async ({
+      page,
+    }) => {
+      const { initialDoc } = await setupDocFromJSON(
+        page,
+        TIPTAP_DEPTH_TWO_JOIN_DOC,
+      );
+
+      await dispatchTipTapDepthTwoJoinStep(page);
+
+      const editorPage = new EditorPage(page);
+      expect(await editorPage.getListItemCount()).toBe(3);
+      expect(await editorPage.getParagraphText(0, [1])).toBe(
+        `Item 1${ZWSP}Item 2`,
+      );
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+      await editorPage.revertAll();
+
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc(initialDoc);
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
+    });
+
+    test("creates one block join suggestion and applies it", async ({
+      page,
+    }) => {
+      await setupDocFromJSON(page, TIPTAP_DEPTH_TWO_JOIN_DOC);
+
+      await dispatchTipTapDepthTwoJoinStep(page);
+
+      const editorPage = new EditorPage(page);
+      expect(await editorPage.getListItemCount()).toBe(3);
+      expect(await editorPage.getParagraphText(0, [1])).toBe(
+        `Item 1${ZWSP}Item 2`,
+      );
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+      await editorPage.applyAll();
+
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc({
+          type: "doc",
+          content: [
+            {
+              type: "orderedList",
+              attrs: {
+                id: "node-1",
+              },
+              content: [
+                {
+                  type: "listItem",
+                  attrs: {
+                    id: "node-2",
+                  },
+                  content: [
+                    {
+                      type: "paragraph",
+                      attrs: {
+                        id: "node-3",
+                      },
+                      content: [{ type: "text", text: "Item 0" }],
+                    },
+                  ],
+                },
+                {
+                  type: "listItem",
+                  attrs: {
+                    id: "node-4",
+                  },
+                  content: [
+                    {
+                      type: "paragraph",
+                      attrs: {
+                        id: "node-5",
+                      },
+                      content: [{ type: "text", text: "Item 1Item 2" }],
+                    },
+                  ],
+                },
+                {
+                  type: "listItem",
+                  attrs: {
+                    id: "node-8",
+                  },
+                  content: [
+                    {
+                      type: "paragraph",
+                      attrs: {
+                        id: "node-9",
+                      },
+                      content: [{ type: "text", text: "Item 3" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        });
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
+    });
+  });
+
+  test.describe("TipTap-style paragraph into list join", () => {
+    test("joins the paragraph into the last list item when suggestions are disabled", async ({
+      page,
+    }) => {
+      await setupDocFromJSON(page, TIPTAP_PARAGRAPH_INTO_LIST_DOC);
+
+      // disable suggestions
+      await page.evaluate(() => {
+        window.pmEditor.setSuggestChangesEnabled(false);
+      });
+
+      const editorPage = new EditorPage(page);
+
+      // 4 list items, one single paragraph
+      await expect(editorPage.editor.locator("p")).toHaveCount(5);
+
+      // join the paragraph into the last list item
+      await dispatchTipTapParagraphIntoListStep(page);
+
+      // expect one less paragraph
+      await expect(editorPage.editor.locator("p")).toHaveCount(4);
+      const lastListItemParagraphLocator = editorPage.editor
+        .locator("ol")
+        .first()
+        .locator("li")
+        .nth(3)
+        .locator("p")
+        .first();
+
+      // the paragraph is now merged into the list item's first paragraph
+      await expect(lastListItemParagraphLocator).toContainText(
+        "sample paragraph",
+      );
+      await expect(lastListItemParagraphLocator).toContainText("Item 4");
+    });
+
+    test("joins the paragraph into the last list item when suggestions are enabled", async ({
+      page,
+      deletionMarksVisibility,
+    }) => {
+      await setupDocFromJSON(page, TIPTAP_PARAGRAPH_INTO_LIST_DOC);
+
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+      // 4 list items, one single paragraph
+      await expect(editorPage.editor.locator("p")).toHaveCount(5);
+
+      // join the paragraph into the last list item
+      await dispatchTipTapParagraphIntoListStep(page);
+
+      // one less paragraph
+      await expect(editorPage.editor.locator("p")).toHaveCount(4);
+      const lastListItemParagraphLocator = editorPage.editor
+        .locator("ol")
+        .first()
+        .locator("li")
+        .nth(3)
+        .locator("p")
+        .first();
+
+      // the paragraph is now merged into the list item's first paragraph
+      await expect(lastListItemParagraphLocator).toContainText(
+        "sample paragraph",
+      );
+      await expect(lastListItemParagraphLocator).toContainText("Item 4");
+
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+      // extract join mark and verify it exists
+      const marks = await editorPage.getProseMirrorMarksJSON();
+
+      const joinMarks = marks.filter(isJoinMarkObject);
+      expect(joinMarks).toHaveLength(1);
+    });
+
+    test("joins the paragraph into the last list item, inserts text adjacent to the join, and reverts all cleanly", async ({
+      page,
+      deletionMarksVisibility,
+    }) => {
+      await setupDocFromJSON(page, TIPTAP_PARAGRAPH_INTO_LIST_DOC);
+
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+      // 4 list items, one single paragraph
+      await expect(editorPage.editor.locator("p")).toHaveCount(5);
+
+      // join the paragraph into the last list item
+      await dispatchTipTapParagraphIntoListStep(page);
+
+      // one less paragraph
+      await expect(editorPage.editor.locator("p")).toHaveCount(4);
+      const lastListItemParagraphLocator = editorPage.editor
+        .locator("ol")
+        .first()
+        .locator("li")
+        .nth(3)
+        .locator("p")
+        .first();
+
+      // the paragraph is now merged into the list item's first paragraph
+      await expect(lastListItemParagraphLocator).toContainText(
+        "sample paragraph",
+      );
+      await expect(lastListItemParagraphLocator).toContainText("Item 4");
+
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+      // extract join mark and verify it exists
+      const marks = await editorPage.getProseMirrorMarksJSON();
+
+      const joinMarks = marks.filter(isJoinMarkObject);
+      expect(joinMarks).toHaveLength(1);
+
+      // verify that the cursor is at the correct spot after the join (should be right at the join point)
+      await editorPage.insertText("FOO");
+      await expect(editorPage.editor.locator("p").nth(3)).toHaveText(
+        `Item 4${ZWSP}FOOsample paragraph`,
+      );
+
+      // revert all
+      await editorPage.revertAll();
+
+      // verify reverted
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc(
+          TIPTAP_PARAGRAPH_INTO_LIST_DOC,
+        );
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
+
+      // verify cursor placement after the revert
+      await editorPage.insertText("BAR");
+      await expect(editorPage.editor.locator("p").nth(4)).toHaveText(
+        "BARsample paragraph",
+      );
+    });
+
+    test("joins the paragraph into the last list item, inserts text adjacent to the join, and reverts only the join cleanly", async ({
+      page,
+      deletionMarksVisibility,
+    }) => {
+      await setupDocFromJSON(page, TIPTAP_PARAGRAPH_INTO_LIST_DOC);
+
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+      // 4 list items, one single paragraph
+      await expect(editorPage.editor.locator("p")).toHaveCount(5);
+
+      // join the paragraph into the last list item
+      await dispatchTipTapParagraphIntoListStep(page);
+
+      // one less paragraph
+      await expect(editorPage.editor.locator("p")).toHaveCount(4);
+      const lastListItemParagraphLocator = editorPage.editor
+        .locator("ol")
+        .first()
+        .locator("li")
+        .nth(3)
+        .locator("p")
+        .first();
+
+      // the paragraph is now merged into the list item's first paragraph
+      await expect(lastListItemParagraphLocator).toContainText(
+        "sample paragraph",
+      );
+      await expect(lastListItemParagraphLocator).toContainText("Item 4");
+
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+      // extract join mark and verify it exists
+      const marks = await editorPage.getProseMirrorMarksJSON();
+
+      const joinMarks = marks.filter(isJoinMarkObject);
+      expect(joinMarks).toHaveLength(1);
+
+      // verify that the cursor is at the correct spot after the join (should be right at the join point)
+      await editorPage.insertText("FOO");
+      await expect(editorPage.editor.locator("p").nth(3)).toHaveText(
+        `Item 4${ZWSP}FOOsample paragraph`,
+      );
+
+      // revert join (will revert the emerged structure suggestion too and the insertion)
+      // insertion is reverted because it is adjacent to the join deletion mark and shares it's suggestion ID
+      await editorPage.revertSuggestion(1);
+
+      // verify reverted
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc(
+          TIPTAP_PARAGRAPH_INTO_LIST_DOC,
+        );
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
+
+      // verify cursor placement after the revert
+      await editorPage.insertText("BAR");
+      await expect(editorPage.editor.locator("p").nth(4)).toHaveText(
+        "BARsample paragraph",
+      );
+    });
+
+    test("joins the paragraph into the last list item, inserts text non adjacent to the join, and reverts only the join cleanly", async ({
+      page,
+      deletionMarksVisibility,
+    }) => {
+      await setupDocFromJSON(page, TIPTAP_PARAGRAPH_INTO_LIST_DOC);
+
+      const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+      // 4 list items, one single paragraph
+      await expect(editorPage.editor.locator("p")).toHaveCount(5);
+
+      // join the paragraph into the last list item
+      await dispatchTipTapParagraphIntoListStep(page);
+
+      // one less paragraph
+      await expect(editorPage.editor.locator("p")).toHaveCount(4);
+      const lastListItemParagraphLocator = editorPage.editor
+        .locator("ol")
+        .first()
+        .locator("li")
+        .nth(3)
+        .locator("p")
+        .first();
+
+      // the paragraph is now merged into the list item's first paragraph
+      await expect(lastListItemParagraphLocator).toContainText(
+        "sample paragraph",
+      );
+      await expect(lastListItemParagraphLocator).toContainText("Item 4");
+
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+      // extract join mark and verify it exists
+      const marks = await editorPage.getProseMirrorMarksJSON();
+
+      const joinMarks = marks.filter(isJoinMarkObject);
+      expect(joinMarks).toHaveLength(1);
+
+      // move the cursor one character to the left so the insertion is not adjacent to the join,
+      // and doesn't share it's suggestion ID
+      await editorPage.pressKey("ArrowLeft");
+
+      // verify that the cursor is at the correct spot after the join (should be here: "Item |4<join>sample paragraph")
+      await editorPage.insertText("FOO");
+      await expect(editorPage.editor.locator("p").nth(3)).toHaveText(
+        `Item FOO4${ZWSP}sample paragraph`,
+      );
+
+      // revert join (will revert the emerged structure suggestion too but no the insertion)
+      // the insertion is not reverted because it is not adjacent to the join deletion mark and doesn't share its suggestion ID
+      await editorPage.revertSuggestion(1);
+
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(1);
+
+      // verify not reverted
+      const expectedNotReverted = await editorPage.getCurrentAndExpectedDoc(
+        TIPTAP_PARAGRAPH_INTO_LIST_DOC,
+      );
+      expect(
+        eq(expectedNotReverted.currentDoc, expectedNotReverted.expectedDoc),
+      ).not.toBe(true);
+
+      // verify fourth list item content
+      await expect(editorPage.editor.locator("li").nth(3)).toHaveText(
+        "Item FOO4",
+      );
+
+      // revert the insertion
+      await editorPage.revertSuggestion(2);
+
+      // verify reverted
+      const expectedReverted = await editorPage.getCurrentAndExpectedDoc(
+        TIPTAP_PARAGRAPH_INTO_LIST_DOC,
+      );
+      expect(
+        eq(expectedReverted.currentDoc, expectedReverted.expectedDoc),
+      ).toBe(true);
+    });
+
+    test("joins the paragraph into the last list item and reverts cleanly - revert all", async ({
+      page,
+    }) => {
+      await setupDocFromJSON(page, TIPTAP_PARAGRAPH_INTO_LIST_DOC);
+
+      const editorPage = new EditorPage(page);
+
+      // join the paragraph into the last list item
+      await dispatchTipTapParagraphIntoListStep(page);
+
+      await editorPage.revertAll();
+
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc(
+          TIPTAP_PARAGRAPH_INTO_LIST_DOC,
+        );
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
+    });
+
+    test("joins the paragraph into the last list item and reverts cleanly - revert one", async ({
+      page,
+    }) => {
+      await setupDocFromJSON(page, TIPTAP_PARAGRAPH_INTO_LIST_DOC);
+
+      const editorPage = new EditorPage(page);
+
+      // join the paragraph into the last list item
+      await dispatchTipTapParagraphIntoListStep(page);
+
+      const marks = await editorPage.getProseMirrorMarksJSON();
+      const joinMarks = marks.filter(isJoinMarkObject);
+      expect(joinMarks).toHaveLength(1);
+
+      await editorPage.revertSuggestion(1);
+
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc(
+          TIPTAP_PARAGRAPH_INTO_LIST_DOC,
+        );
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
+    });
+
+    test("joins the paragraph into the last list item and applies cleanly", async ({
+      page,
+    }) => {
+      await setupDocFromJSON(page, TIPTAP_PARAGRAPH_INTO_LIST_DOC);
+
+      const editorPage = new EditorPage(page);
+
+      // join the paragraph into the last list item
+      await dispatchTipTapParagraphIntoListStep(page);
+
+      await editorPage.applyAll();
+
+      const { currentDoc, expectedDoc } =
+        await editorPage.getCurrentAndExpectedDoc({
+          type: "doc",
+          content: [
+            {
+              type: "orderedList",
+              attrs: {
+                order: 1,
+                id: "node-0",
+              },
+              content: [
+                {
+                  type: "listItem",
+                  attrs: {
+                    id: "node-1",
+                  },
+                  content: [
+                    {
+                      type: "paragraph",
+                      attrs: {
+                        id: "node-2",
+                      },
+                      content: [{ type: "text", text: "Item 1" }],
+                    },
+                  ],
+                },
+                {
+                  type: "listItem",
+                  attrs: {
+                    id: "node-3",
+                  },
+                  content: [
+                    {
+                      type: "paragraph",
+                      attrs: {
+                        id: "node-4",
+                      },
+                      content: [{ type: "text", text: "Item 2" }],
+                    },
+                  ],
+                },
+                {
+                  type: "listItem",
+                  attrs: {
+                    id: "node-5",
+                  },
+                  content: [
+                    {
+                      type: "paragraph",
+                      attrs: {
+                        id: "node-6",
+                      },
+                      content: [{ type: "text", text: "Item 3" }],
+                    },
+                  ],
+                },
+                {
+                  type: "listItem",
+                  attrs: {
+                    id: "node-7",
+                  },
+                  content: [
+                    {
+                      type: "paragraph",
+                      attrs: {
+                        id: "node-8",
+                      },
+                      content: [
+                        { type: "text", text: "Item 4sample paragraph" },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        });
+      expect(eq(currentDoc, expectedDoc)).toBe(true);
+    });
+  });
+
+  test.describe("TipTap-style new paragraph into list join", () => {
+    test("joins the new paragraph into the last list item when suggestions are disabled", async ({
+      page,
+    }) => {
+      await setupDocFromJSON(page, TIPTAP_NEW_PARAGRAPH_INTO_LIST_DOC);
+
+      await page.evaluate(() => {
+        window.pmEditor.setCursorToEnd();
+      });
+
+      const editorPage = new EditorPage(page);
+      // the document already uses ids 0-8
+      await editorPage.setNextNodeId(9);
+
+      await expect(editorPage.editor.locator("li")).toHaveCount(4);
+      await expect(editorPage.editor.locator("p")).toHaveCount(4);
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(0);
+
+      // from the last list item, press Enter to create a new list item
+      await editorPage.pressKey("Enter");
+      await expect(editorPage.editor.locator("li")).toHaveCount(5);
+      await expect(editorPage.editor.locator("p")).toHaveCount(5);
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(0);
+
+      // press Enter again, to turn the newly added list item into a root-level paragraph
+      await editorPage.pressKey("Enter");
+      await expect(editorPage.editor.locator("li")).toHaveCount(4);
+      await expect(editorPage.editor.locator("p")).toHaveCount(5);
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(0);
+
+      // enter text into the paragraph
+      await editorPage.insertText("sample paragraph");
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(1);
+
+      // disable suggestions
+      await page.evaluate(() => {
+        window.pmEditor.setSuggestChangesEnabled(false);
+      });
+
+      // put the cursor to the start of the paragraph
+      await editorPage.pressKey("Home", { waitForSelectionChange: true });
+
+      // join the paragraph into the last list item
+      await dispatchTipTapNewParagraphIntoListStep(page);
+
+      // the number of list items unchanged
+      await expect(editorPage.editor.locator("li")).toHaveCount(4);
+      // expect one less paragraph
+      await expect(editorPage.editor.locator("p")).toHaveCount(4);
+
+      // the paragraph is now merged into the list item's first paragraph
+      await expect(editorPage.getParagraphAt(3)).toHaveText(
+        "Item 4sample paragraph",
+      );
+
+      // the structure mark is gone, insertion remains
+      // no join mark because track changes off
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(1);
+
+      // verify cursor position by entering text
+      await editorPage.insertText("FOO", { waitForSelectionChange: true });
+      await expect(editorPage.getParagraphAt(3)).toHaveText(
+        "Item 4FOOsample paragraph",
+      );
+    });
+
+    test("joins the new paragraph into the last list item when suggestions are enabled", async ({
+      page,
+    }) => {
+      await setupDocFromJSON(page, TIPTAP_NEW_PARAGRAPH_INTO_LIST_DOC);
+
+      await page.evaluate(() => {
+        window.pmEditor.setCursorToEnd();
+      });
+
+      const editorPage = new EditorPage(page);
+      // the document already uses ids 0-8
+      await editorPage.setNextNodeId(9);
+
+      await expect(editorPage.editor.locator("li")).toHaveCount(4);
+      await expect(editorPage.editor.locator("p")).toHaveCount(4);
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(0);
+
+      // from the last list item, press Enter to create a new list item
+      await editorPage.pressKey("Enter");
+      await expect(editorPage.editor.locator("li")).toHaveCount(5);
+      await expect(editorPage.editor.locator("p")).toHaveCount(5);
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(0);
+
+      // press Enter again, to turn the newly added list item into a root-level paragraph
+      await editorPage.pressKey("Enter");
+      await expect(editorPage.editor.locator("li")).toHaveCount(4);
+      await expect(editorPage.editor.locator("p")).toHaveCount(5);
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(0);
+
+      // enter text into the paragraph
+      await editorPage.insertText("sample paragraph");
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+      expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(1);
+
+      // put the cursor to the start of the paragraph
+      await editorPage.pressKey("Home", { waitForSelectionChange: true });
+
+      // join the paragraph into the last list item
+      await dispatchTipTapNewParagraphIntoListStep(page);
+
+      // the number of list items unchanged
+      await expect(editorPage.editor.locator("li")).toHaveCount(4);
+      // expect one less paragraph
+      await expect(editorPage.editor.locator("p")).toHaveCount(4);
+
+      // the paragraph is now merged into the list item's first paragraph
+      await expect(editorPage.getParagraphAt(3)).toHaveText(
+        "Item 4sample paragraph",
+      );
+
+      // the structure mark is gone, insertion remains
+      // no join mark because the joined paragraph was a provisional structure add
+      expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+      expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(1);
+      // extract join marks and verify none exist
+      const marks = await editorPage.getProseMirrorMarksJSON();
+      const joinMarks = marks.filter(isJoinMarkObject);
+      expect(joinMarks).toHaveLength(0);
+
+      // verify cursor position by entering text
+      await editorPage.insertText("FOO", { waitForSelectionChange: true });
+      await expect(editorPage.getParagraphAt(3)).toHaveText(
+        "Item 4FOOsample paragraph",
+      );
+    });
+  });
+});

--- a/src/features/joinOnDelete/__tests__/listWithJoinsAndStructureMarks.doc.json
+++ b/src/features/joinOnDelete/__tests__/listWithJoinsAndStructureMarks.doc.json
@@ -1,0 +1,422 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "orderedList",
+      "attrs": {
+        "id": "bl_01ktxskse0e99v6xa382yfrp2p",
+        "start": 1,
+        "type": null
+      },
+      "content": [
+        {
+          "type": "listItem",
+          "attrs": {
+            "id": "bl_01ktxskse0e99v6xa384fg1q32"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "id": "bl_01ktxskqa9fzqbsyvn1mzm2431",
+                "textAlign": null
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Item 1"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "attrs": {
+            "id": "bl_01ktxskvggfx48r5vqr4h7mwcq"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "id": "bl_01ktxskvggfx48r5vqr9rdm3kd",
+                "textAlign": null
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Item 2"
+                },
+                {
+                  "type": "text",
+                  "marks": [
+                    {
+                      "type": "deletion",
+                      "attrs": {
+                        "id": "sg_01kty2whj7fn2s9bbvr6erc1sx",
+                        "type": "join",
+                        "data": {
+                          "leftNodes": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "id": "bl_01ktxskvggfx48r5vqr9rdm3kd",
+                                "textAlign": null
+                              },
+                              "marks": []
+                            }
+                          ],
+                          "rightNodes": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "id": "bl_01ktxskxfdf46vgthpw6qcqp61",
+                                "textAlign": null
+                              },
+                              "marks": [
+                                {
+                                  "type": "structure",
+                                  "attrs": {
+                                    "id": "sg_01kty2wfs0evsrdf0xz9b0dbvj",
+                                    "data": {
+                                      "op": {
+                                        "op": "move",
+                                        "from": [
+                                          {
+                                            "nodeId": "bl_01ktxskxfdf46vgthpw02etqd7",
+                                            "nodeType": "listItem",
+                                            "nodeAttrs": {
+                                              "id": "bl_01ktxskxfdf46vgthpw02etqd7"
+                                            },
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [null, null],
+                                            "childIndex": 0
+                                          },
+                                          {
+                                            "nodeId": "bl_01ktxskse0e99v6xa382yfrp2p",
+                                            "nodeType": "orderedList",
+                                            "nodeAttrs": {
+                                              "id": "bl_01ktxskse0e99v6xa382yfrp2p",
+                                              "start": 1,
+                                              "type": null
+                                            },
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              "bl_01ktxskvggfx48r5vqr4h7mwcq",
+                                              null
+                                            ],
+                                            "childIndex": 2
+                                          },
+                                          {
+                                            "nodeId": "__doc__",
+                                            "nodeType": "__doc__",
+                                            "nodeAttrs": {},
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              null,
+                                              "bl_01kty1ae62er586ps1tfq2e704"
+                                            ],
+                                            "childIndex": 0
+                                          }
+                                        ],
+                                        "to": [
+                                          {
+                                            "nodeId": "__doc__",
+                                            "nodeType": "__doc__",
+                                            "nodeAttrs": {},
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              "bl_01ktxskse0e99v6xa382yfrp2p",
+                                              "bl_01kty1ae62er586ps1tfq2e704"
+                                            ],
+                                            "childIndex": 1
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "authorId": "user_38ybF4w8QkHQUYIPFY3kocM4QDi",
+                                    "block": null,
+                                    "parentId": null,
+                                    "sourceId": null
+                                  }
+                                },
+                                {
+                                  "type": "structure",
+                                  "attrs": {
+                                    "id": "sg_01kty2whj7fn2s9bbvr6erc1sx",
+                                    "data": {
+                                      "op": {
+                                        "op": "move",
+                                        "from": [
+                                          {
+                                            "nodeId": "__doc__",
+                                            "nodeType": "__doc__",
+                                            "nodeAttrs": {},
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              "bl_01ktxskse0e99v6xa382yfrp2p",
+                                              "bl_01kty1ae62er586ps1tfq2e704"
+                                            ],
+                                            "childIndex": 1
+                                          }
+                                        ],
+                                        "to": [
+                                          {
+                                            "nodeId": "bl_01ktxskvggfx48r5vqr4h7mwcq",
+                                            "nodeType": "listItem",
+                                            "nodeAttrs": {
+                                              "id": "bl_01ktxskvggfx48r5vqr4h7mwcq"
+                                            },
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              "bl_01ktxskvggfx48r5vqr9rdm3kd",
+                                              null
+                                            ],
+                                            "childIndex": 1
+                                          },
+                                          {
+                                            "nodeId": "bl_01ktxskse0e99v6xa382yfrp2p",
+                                            "nodeType": "orderedList",
+                                            "nodeAttrs": {
+                                              "id": "bl_01ktxskse0e99v6xa382yfrp2p",
+                                              "start": 1,
+                                              "type": null
+                                            },
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              "bl_01ktxskse0e99v6xa384fg1q32",
+                                              null
+                                            ],
+                                            "childIndex": 1
+                                          },
+                                          {
+                                            "nodeId": "__doc__",
+                                            "nodeType": "__doc__",
+                                            "nodeAttrs": {},
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              null,
+                                              "bl_01kty1ae62er586ps1tfq2e704"
+                                            ],
+                                            "childIndex": 0
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "authorId": null,
+                                    "block": null,
+                                    "parentId": null,
+                                    "sourceId": null
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "authorId": "user_38ybF4w8QkHQUYIPFY3kocM4QDi",
+                        "block": null,
+                        "parentId": null,
+                        "sourceId": null
+                      }
+                    }
+                  ],
+                  "text": "​"
+                },
+                {
+                  "type": "text",
+                  "text": "Item 3"
+                },
+                {
+                  "type": "text",
+                  "marks": [
+                    {
+                      "type": "deletion",
+                      "attrs": {
+                        "id": "sg_01kty2w4zgfbqrebnczmtd5qvv",
+                        "type": "join",
+                        "data": {
+                          "leftNodes": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "id": "bl_01ktxskxfdf46vgthpw6qcqp61",
+                                "textAlign": null
+                              },
+                              "marks": []
+                            }
+                          ],
+                          "rightNodes": [
+                            {
+                              "type": "paragraph",
+                              "attrs": {
+                                "id": "bl_01ktxsm09tf93b23wswbwbyt6g",
+                                "textAlign": null
+                              },
+                              "marks": [
+                                {
+                                  "type": "structure",
+                                  "attrs": {
+                                    "id": "sg_01kty2w3eje5w8m6jv5c9yyb32",
+                                    "data": {
+                                      "op": {
+                                        "op": "move",
+                                        "from": [
+                                          {
+                                            "nodeId": "bl_01ktxsm09tf93b23wsw54ygxes",
+                                            "nodeType": "listItem",
+                                            "nodeAttrs": {
+                                              "id": "bl_01ktxsm09tf93b23wsw54ygxes"
+                                            },
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [null, null],
+                                            "childIndex": 0
+                                          },
+                                          {
+                                            "nodeId": "bl_01ktxskse0e99v6xa382yfrp2p",
+                                            "nodeType": "orderedList",
+                                            "nodeAttrs": {
+                                              "id": "bl_01ktxskse0e99v6xa382yfrp2p",
+                                              "start": 1,
+                                              "type": null
+                                            },
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              "bl_01ktxskxfdf46vgthpw02etqd7",
+                                              null
+                                            ],
+                                            "childIndex": 3
+                                          },
+                                          {
+                                            "nodeId": "__doc__",
+                                            "nodeType": "__doc__",
+                                            "nodeAttrs": {},
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              null,
+                                              "bl_01kty1ae62er586ps1tfq2e704"
+                                            ],
+                                            "childIndex": 0
+                                          }
+                                        ],
+                                        "to": [
+                                          {
+                                            "nodeId": "__doc__",
+                                            "nodeType": "__doc__",
+                                            "nodeAttrs": {},
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              "bl_01ktxskse0e99v6xa382yfrp2p",
+                                              "bl_01kty1ae62er586ps1tfq2e704"
+                                            ],
+                                            "childIndex": 1
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "authorId": "user_38ybF4w8QkHQUYIPFY3kocM4QDi",
+                                    "block": null,
+                                    "parentId": null,
+                                    "sourceId": null
+                                  }
+                                },
+                                {
+                                  "type": "structure",
+                                  "attrs": {
+                                    "id": "sg_01kty2w4zgfbqrebnczmtd5qvv",
+                                    "data": {
+                                      "op": {
+                                        "op": "move",
+                                        "from": [
+                                          {
+                                            "nodeId": "__doc__",
+                                            "nodeType": "__doc__",
+                                            "nodeAttrs": {},
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              "bl_01ktxskse0e99v6xa382yfrp2p",
+                                              "bl_01kty1ae62er586ps1tfq2e704"
+                                            ],
+                                            "childIndex": 1
+                                          }
+                                        ],
+                                        "to": [
+                                          {
+                                            "nodeId": "bl_01ktxskxfdf46vgthpw02etqd7",
+                                            "nodeType": "listItem",
+                                            "nodeAttrs": {
+                                              "id": "bl_01ktxskxfdf46vgthpw02etqd7"
+                                            },
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              "bl_01ktxskxfdf46vgthpw6qcqp61",
+                                              null
+                                            ],
+                                            "childIndex": 1
+                                          },
+                                          {
+                                            "nodeId": "bl_01ktxskse0e99v6xa382yfrp2p",
+                                            "nodeType": "orderedList",
+                                            "nodeAttrs": {
+                                              "id": "bl_01ktxskse0e99v6xa382yfrp2p",
+                                              "start": 1,
+                                              "type": null
+                                            },
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              "bl_01ktxskvggfx48r5vqr4h7mwcq",
+                                              null
+                                            ],
+                                            "childIndex": 2
+                                          },
+                                          {
+                                            "nodeId": "__doc__",
+                                            "nodeType": "__doc__",
+                                            "nodeAttrs": {},
+                                            "nodeMarks": [],
+                                            "childSiblingIds": [
+                                              null,
+                                              "bl_01kty1ae62er586ps1tfq2e704"
+                                            ],
+                                            "childIndex": 0
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "authorId": null,
+                                    "block": null,
+                                    "parentId": null,
+                                    "sourceId": null
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "authorId": "user_38ybF4w8QkHQUYIPFY3kocM4QDi",
+                        "block": null,
+                        "parentId": null,
+                        "sourceId": null
+                      }
+                    }
+                  ],
+                  "text": "​"
+                },
+                {
+                  "type": "text",
+                  "text": "Item 4"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "attrs": {
+        "id": "bl_01kty1ae62er586ps1tfq2e704",
+        "textAlign": null
+      }
+    }
+  ]
+}

--- a/src/features/joinOnDelete/__tests__/listWithJoinsAndStructureMarks.playwright.test.ts
+++ b/src/features/joinOnDelete/__tests__/listWithJoinsAndStructureMarks.playwright.test.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "../../../__tests__/playwrightBaseTest.js";
+import { setupDocFromJSON } from "../../../__tests__/playwrightHelpers.js";
+import { EditorPage } from "../../../__tests__/playwrightPage.js";
+import { ZWSP } from "../../../constants.js";
+import initialDoc from "./listWithJoinsAndStructureMarks.doc.json" with { type: "json" };
+
+/**
+ * This initial document reproduces a state in the TipTap editor after joining multiple list items with backspace
+ * Backspace #1 - lift a paragraph out of the list, Backspace #2 - join the paragraph with the above list item,
+ * place the cursor at the start, repeat
+ * Re-creating this state from scratch here is very verbose because the plugin doesn't use tiptap, so you would have to have multiple serialized steps to replay
+ * So instead we have a document with all the marks already in place, and we test their reversal
+ */
+
+test.describe("List with joins and structure marks", () => {
+  test("should revert all joins one by one and get back to a clean list", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, initialDoc);
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+    await expect(editorPage.getParagraphs()).toHaveCount(3);
+    await expect(editorPage.getListItems()).toHaveCount(2);
+    await expect(editorPage.getParagraphAt(0)).toHaveText("Item 1");
+    await expect(editorPage.getParagraphAt(1)).toHaveText(
+      `Item 2${ZWSP}Item 3${ZWSP}Item 4`,
+    );
+    // two join marks, 0 structure marks, but there are serialized structure marks in the join metadata
+    expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(2);
+
+    await editorPage.revertSuggestion(
+      "sg_01kty2whj7fn2s9bbvr6erc1sx" as unknown as number,
+    );
+
+    await editorPage.revertSuggestion(
+      "sg_01kty2w4zgfbqrebnczmtd5qvv" as unknown as number,
+    );
+
+    await expect(editorPage.getParagraphs()).toHaveCount(5);
+    await expect(editorPage.getListItems()).toHaveCount(4);
+    await expect(editorPage.getParagraphAt(0)).toHaveText("Item 1");
+    await expect(editorPage.getParagraphAt(1)).toHaveText("Item 2");
+    await expect(editorPage.getParagraphAt(2)).toHaveText("Item 3");
+    await expect(editorPage.getParagraphAt(3)).toHaveText("Item 4");
+
+    expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+  });
+
+  test("should revert all joins one by one in reverse order and get back to a clean list", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, initialDoc);
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+    await expect(editorPage.getParagraphs()).toHaveCount(3);
+    await expect(editorPage.getListItems()).toHaveCount(2);
+    await expect(editorPage.getParagraphAt(0)).toHaveText("Item 1");
+    await expect(editorPage.getParagraphAt(1)).toHaveText(
+      `Item 2${ZWSP}Item 3${ZWSP}Item 4`,
+    );
+    // two join marks, 0 structure marks, but there are serialized structure marks in the join metadata
+    expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(2);
+
+    await editorPage.revertSuggestion(
+      "sg_01kty2w4zgfbqrebnczmtd5qvv" as unknown as number,
+    );
+
+    await editorPage.revertSuggestion(
+      "sg_01kty2whj7fn2s9bbvr6erc1sx" as unknown as number,
+    );
+
+    await expect(editorPage.getParagraphs()).toHaveCount(5);
+    await expect(editorPage.getListItems()).toHaveCount(4);
+    await expect(editorPage.getParagraphAt(0)).toHaveText("Item 1");
+    await expect(editorPage.getParagraphAt(1)).toHaveText("Item 2");
+    await expect(editorPage.getParagraphAt(2)).toHaveText("Item 3");
+    await expect(editorPage.getParagraphAt(3)).toHaveText("Item 4");
+
+    expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+  });
+
+  test("should revert all joins at once and get back to a clean list", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, initialDoc);
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+    await expect(editorPage.getParagraphs()).toHaveCount(3);
+    await expect(editorPage.getListItems()).toHaveCount(2);
+    await expect(editorPage.getParagraphAt(0)).toHaveText("Item 1");
+    await expect(editorPage.getParagraphAt(1)).toHaveText(
+      `Item 2${ZWSP}Item 3${ZWSP}Item 4`,
+    );
+    // two join marks, 0 structure marks, but there are serialized structure marks in the join metadata
+    expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(2);
+
+    await editorPage.revertAll();
+
+    await expect(editorPage.getParagraphs()).toHaveCount(5);
+    await expect(editorPage.getListItems()).toHaveCount(4);
+    await expect(editorPage.getParagraphAt(0)).toHaveText("Item 1");
+    await expect(editorPage.getParagraphAt(1)).toHaveText("Item 2");
+    await expect(editorPage.getParagraphAt(2)).toHaveText("Item 3");
+    await expect(editorPage.getParagraphAt(3)).toHaveText("Item 4");
+
+    expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+  });
+});

--- a/src/features/joinOnDelete/docs/adr/0001-block-join-suggestion-metadata.md
+++ b/src/features/joinOnDelete/docs/adr/0001-block-join-suggestion-metadata.md
@@ -1,0 +1,26 @@
+# Multi-Depth Block Join Suggestion Metadata
+
+Block join suggestions already stored the nodes that existed on both sides of a
+physical join so rejection could split joined content and restore node markup.
+This ADR is about the metadata shape needed to represent joins at more than one
+depth.
+
+Current metadata uses child-first `leftNodes` and `rightNodes` arrays. The first
+pair is the visible textblock pair; later pairs are structural parent pairs.
+This replaced the legacy single-pair `leftNode` and `rightNode` fields, which
+could only describe a depth-1 join.
+
+Legacy documents may still contain one `leftNode` and one `rightNode`. Normalize
+that shape to one-item arrays before revert so old documents remain rejectable,
+but write current documents with the array shape.
+
+The current maximum supported join depth is 2, which covers the TipTap list
+behavior where Backspace joins both adjacent list-item paragraphs and their
+parent list items. Reject metadata deeper than the configured maximum instead of
+truncating it, because partial revert of unknown structure can create a document
+that never existed.
+
+When any joined node has a Structure add suggestion, perform the physical join
+but do not create a Block join suggestion. Joining away provisional added
+structure cancels that pending add rather than creating a second review
+artifact.

--- a/src/features/joinOnDelete/docs/adr/0002-structure-suggestions-revealed-by-block-join-rejection.md
+++ b/src/features/joinOnDelete/docs/adr/0002-structure-suggestions-revealed-by-block-join-rejection.md
@@ -1,0 +1,44 @@
+# Structure Suggestions Revealed By Block Join Rejection
+
+Rejecting a Block join suggestion can split joined content back into nodes whose
+serialized metadata contains Structure marks. Those Structure marks become live
+Structure suggestions again only after the Block join suggestion is rejected.
+
+When restoring node markup from Block join suggestion metadata, preserve any
+already-live Structure marks on the split nodes instead of treating serialized
+marks as a complete replacement. Equivalent Structure marks are matched by
+Structure operation: Structure add suggestions use the same suggestion id, and
+Structure move suggestions use the same source and destination Parent chains.
+
+All apply-all and revert-all commands must also handle Structure marks revealed
+by Block join suggestion processing. Applying all suggestions runs a second
+direction-matching Structure suggestion pass after normal suggestion cleanup.
+Reverting all suggestions first rejects Block join suggestions as individual
+units, including their restored Structure suggestions, then runs the generic
+Structure suggestion cleanup for anything still left.
+
+Block join suggestion rejection also rejects the Structure suggestions restored
+from that join's serialized metadata. The restored Structure suggestion ids come
+from the selected Block join suggestion metadata, not from a document diff after
+the split. This keeps single-suggestion commands scoped: unrelated Structure
+suggestions that were already live in the document remain untouched. Revert-all
+uses the same per-join restored-Structure cleanup before falling back to broad
+all-suggestion cleanup.
+
+When a restored Structure suggestion has the same id as the rejected Block join
+suggestion, reject that same-id Structure suggestion first. TipTap
+paragraph-into-list transaction shaping deliberately gives the Structure move
+and Block join the same suggestion id, because they are one visible edit.
+Same-id restored Structure rejection lets that semantic unit reject before
+broader cleanup considers older Structure suggestions that happened to be
+serialized in the same Block join metadata. After the same-id pass, reject the
+remaining restored Structure suggestion ids to preserve existing broad cleanup
+behavior.
+
+We rejected treating serialized Block join metadata as authoritative over the
+current node marks, because sequential Block join rejections can materialize
+Structure marks before an earlier join is restored. Overwriting those current
+marks loses pending Structure suggestions. We also rejected using generic
+right-to-left suggestion traversal as the primary fix, because traversal order
+does not address stale serialized markup overwriting Structure marks that are
+already live on a node.

--- a/src/features/joinOnDelete/index.ts
+++ b/src/features/joinOnDelete/index.ts
@@ -1,47 +1,111 @@
 import {
   Mark,
   type Node,
-  type Attrs,
   type MarkType,
   type ResolvedPos,
+  type Schema,
 } from "prosemirror-model";
 import { canJoin, Transform } from "prosemirror-transform";
 import { ZWSP } from "../../constants.js";
 import { type Transaction } from "prosemirror-state";
 import { type SuggestionId } from "../../generateId.js";
 import { getSuggestionMarks } from "../../utils.js";
+import { areEquivalentStructureMarks } from "../wrapUnwrap/areEquivalentStructureMarks.js";
+import { guardStructureMarkAttrs } from "../wrapUnwrap/types.js";
+import {
+  type SerializedJoinNode,
+  type JoinCandidate,
+  type JoinPair,
+} from "./types.js";
+import {
+  MAX_BLOCK_JOIN_DEPTH,
+  normalizeJoinNodesMetadata,
+} from "./normalizeJoinNodesMetadata.js";
+import { isJoinMark } from "./types.js";
 
-interface JoinMarkAttrs {
-  type: "join";
-  data: {
-    leftNode: { type: string; attrs: object; marks: object[] };
-    rightNode: { type: string; attrs: object; marks: object[] };
+function serializeJoinNode(node: Node): SerializedJoinNode {
+  return {
+    type: node.type.name,
+    attrs: node.attrs,
+    marks: node.marks.map(
+      (mark) => mark.toJSON() as { attrs: Record<string, unknown> },
+    ),
   };
 }
 
-export function isJoinMarkAttrs(attrs: Attrs): attrs is JoinMarkAttrs {
-  if (attrs["type"] !== "join") return false;
-  if (attrs["data"] == null) return false;
+function marksFromJSON(schema: Schema, markData: object[]) {
+  return markData.map((markData) => Mark.fromJSON(schema, markData));
+}
 
-  const data = attrs["data"] as Partial<JoinMarkAttrs["data"]>;
-  if (data.leftNode == null || data.rightNode == null) return false;
+// when we revert a block join deletion mark, we restore nodes on both sides of the mark using leftNodes rightNodes metadata
+// but existing left and right nodes may have structure marks that we need to preserve
+function mergeSerializedMarksWithCurrentStructureMarks(
+  tr: Transform,
+  pos: number,
+  serializedMarks: Mark[],
+) {
+  const currentNode = tr.doc.nodeAt(pos);
+  if (!currentNode) return serializedMarks;
 
-  if (
-    typeof data.leftNode.type !== "string" ||
-    typeof data.rightNode.type !== "string"
-  )
-    return false;
-  if (
-    typeof data.leftNode.attrs !== "object" ||
-    typeof data.rightNode.attrs !== "object"
-  )
-    return false;
-  if (
-    !Array.isArray(data.leftNode.marks) ||
-    !Array.isArray(data.rightNode.marks)
-  )
-    return false;
+  const { structure } = getSuggestionMarks(tr.doc.type.schema);
+  const mergedMarks = [...serializedMarks];
+
+  for (const currentMark of currentNode.marks) {
+    if (currentMark.type !== structure) continue;
+
+    const alreadyIncluded = mergedMarks.some(
+      (mark) =>
+        mark.type === structure &&
+        areEquivalentStructureMarks(mark, currentMark),
+    );
+
+    if (!alreadyIncluded) {
+      mergedMarks.push(currentMark);
+    }
+  }
+
+  return mergedMarks;
+}
+
+function restoreNodeMarkup(
+  tr: Transform,
+  pos: number,
+  node: SerializedJoinNode,
+) {
+  const nodeType = tr.doc.type.schema.nodes[node.type];
+  if (!nodeType) return false;
+
+  const marks = mergeSerializedMarksWithCurrentStructureMarks(
+    tr,
+    pos,
+    marksFromJSON(tr.doc.type.schema, node.marks),
+  );
+
+  tr.setNodeMarkup(pos, nodeType, node.attrs, marks);
   return true;
+}
+
+// collect structure suggestion IDs that will be re-introduced into the document after the join is reverted
+function getRestoredStructureSuggestionIds(
+  joinNodes: {
+    leftNodes: SerializedJoinNode[];
+    rightNodes: SerializedJoinNode[];
+  },
+  schema: Schema,
+): Set<SuggestionId> {
+  const { structure } = getSuggestionMarks(schema);
+  const restoredStructureSuggestionIds = new Set<SuggestionId>();
+
+  for (const node of [...joinNodes.leftNodes, ...joinNodes.rightNodes]) {
+    const marks = marksFromJSON(schema, node.marks);
+    for (const mark of marks) {
+      if (mark.type !== structure) continue;
+      if (!guardStructureMarkAttrs(mark.attrs)) continue;
+      restoredStructureSuggestionIds.add(mark.attrs.id);
+    }
+  }
+
+  return restoredStructureSuggestionIds;
 }
 
 export function maybeRevertJoinMark(
@@ -50,58 +114,59 @@ export function maybeRevertJoinMark(
   to: number,
   node: Node,
   markType: MarkType,
-) {
+): false | { restoredStructureSuggestionIds: Set<SuggestionId> } {
   const mark = node.marks.find((mark) => mark.type === markType);
-  if (!mark || mark.attrs["type"] !== "join" || node.text !== ZWSP)
-    return false;
+  if (!mark || !isJoinMark(mark) || node.text !== ZWSP) return false;
 
-  // this is a mark of type join
-  // split the current node at this mark position
-  // delete this mark together with its zwsp content
-  // assign left and right node (after the split) properties from the mark's data
+  const joinNodes = normalizeJoinNodesMetadata(mark.attrs);
+  if (!joinNodes) return false;
+
+  for (const node of [...joinNodes.leftNodes, ...joinNodes.rightNodes]) {
+    const nodeType = tr.doc.type.schema.nodes[node.type];
+    if (!nodeType) return false;
+
+    try {
+      marksFromJSON(tr.doc.type.schema, node.marks);
+    } catch {
+      return false;
+    }
+  }
+  const restoredStructureSuggestionIds = getRestoredStructureSuggestionIds(
+    joinNodes,
+    tr.doc.type.schema,
+  );
+
+  // Reverting a join marker removes its ZWSP anchor, splits at that position,
+  // and restores markup because ProseMirror split creates nodes with defaults.
+  const joinDepth = joinNodes.leftNodes.length;
   tr.delete(from, to);
-  tr.split(from);
+  tr.split(from, joinDepth);
 
-  // insertionFrom is now at the end of the left node (but before the closing token)
-  // after() will give us the position after the closing token (but before the next opening token) - exactly the split pos
-  const $insertionFrom = tr.doc.resolve(from);
-  const $splitPos = tr.doc.resolve($insertionFrom.after());
+  const $splitFrom = tr.doc.resolve(from);
+  const baseDepth = $splitFrom.depth;
+  let rightPos = $splitFrom.after(baseDepth - joinDepth + 1);
 
-  const { attrs } = mark;
+  // Metadata is stored child-first, but markup must be restored outer-first so
+  // positions inside the newly split structure remain addressable.
+  for (let index = joinDepth - 1; index >= 0; index -= 1) {
+    const leftNode = joinNodes.leftNodes[index];
+    const rightNode = joinNodes.rightNodes[index];
+    if (!leftNode || !rightNode) return false;
 
-  if (!isJoinMarkAttrs(attrs) || !$splitPos.nodeBefore || !$splitPos.nodeAfter)
-    return false;
+    const leftPos = $splitFrom.before(baseDepth - index);
 
-  // restore left and right node type, attrs and marks, as they were before the join
-  const { leftNode, rightNode } = attrs.data;
+    if (
+      !restoreNodeMarkup(tr, leftPos, leftNode) ||
+      !restoreNodeMarkup(tr, rightPos, rightNode)
+    ) {
+      return false;
+    }
 
-  const leftNodeType = tr.doc.type.schema.nodes[leftNode.type];
-  const rightNodeType = tr.doc.type.schema.nodes[rightNode.type];
+    // Each deeper right node starts one position inside the right node restored before it.
+    rightPos += 1;
+  }
 
-  const leftNodeMarks = leftNode.marks.map((markData) =>
-    Mark.fromJSON(tr.doc.type.schema, markData),
-  );
-  const rightNodeMarks = rightNode.marks.map((markData) =>
-    Mark.fromJSON(tr.doc.type.schema, markData),
-  );
-
-  if (!leftNodeType || !rightNodeType) return false;
-
-  tr.setNodeMarkup(
-    $splitPos.pos - $splitPos.nodeBefore.nodeSize,
-    leftNodeType,
-    leftNode.attrs,
-    leftNodeMarks,
-  );
-
-  tr.setNodeMarkup(
-    $splitPos.pos,
-    rightNodeType,
-    rightNode.attrs,
-    rightNodeMarks,
-  );
-
-  return true;
+  return { restoredStructureSuggestionIds };
 }
 
 /**
@@ -172,45 +237,46 @@ export function joinNodesAndMarkJoinPoints(
     if (node.isInline) return false;
 
     const endOfNode = pos + node.nodeSize;
-    // make sure the node ends within the range
     if (endOfNode >= blockRange.$to.pos) return true;
 
-    const $endOfNode = doc.resolve(endOfNode);
-    // make sure we are between two nodes
-    if (!$endOfNode.nodeBefore || !$endOfNode.nodeAfter) return false;
+    // List-item joins can start between non-textblock nodes; expand inward to
+    // capture the visible textblock pair and its structural parent pair.
+    const joinCandidate = getJoinCandidateAtBoundary(
+      doc,
+      endOfNode,
+      from,
+      to,
+      MAX_BLOCK_JOIN_DEPTH,
+    );
 
-    // we cannot insert zwsp text nodes into non-textblock nodes
-    if (!$endOfNode.nodeBefore.isTextblock || !$endOfNode.nodeAfter.isTextblock)
-      return true;
+    if (!joinCandidate) return true;
 
-    const mappedEndOfNode = transform.mapping.map(endOfNode);
-    const $mappedEndOfNode = transform.doc.resolve(mappedEndOfNode);
+    const mappedJoinPos = transform.mapping.map(joinCandidate.joinPos);
 
     if (
-      !canJoin(transform.doc, mappedEndOfNode) ||
-      !$mappedEndOfNode.nodeBefore ||
-      !$mappedEndOfNode.nodeAfter
+      !canApplyJoinCandidate(
+        transform.doc,
+        mappedJoinPos,
+        joinCandidate.leftNodes.length,
+      )
     ) {
       return true;
     }
 
-    const leftNode = {
-      type: $endOfNode.nodeBefore.type.name,
-      attrs: $endOfNode.nodeBefore.attrs,
-      marks: $endOfNode.nodeBefore.marks.map((mark) => mark.toJSON() as object),
-    };
+    const shouldSuppressJoinMark = [
+      ...joinCandidate.leftNodes,
+      ...joinCandidate.rightNodes,
+    ].some((node) => hasStructureAddMark(node));
 
-    const rightNode = {
-      type: $endOfNode.nodeAfter.type.name,
-      attrs: $endOfNode.nodeAfter.attrs,
-      marks: $endOfNode.nodeAfter.marks.map((mark) => mark.toJSON() as object),
-    };
+    transform.join(mappedJoinPos, joinCandidate.leftNodes.length);
 
-    transform.join(mappedEndOfNode);
+    // Joining provisional structure cancels its pending add instead of creating
+    // a second review artifact for the same user action.
+    if (shouldSuppressJoinMark) return false;
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const joinStep = transform.steps[transform.steps.length - 1]!;
-    const joinPos = joinStep.getMap().map(mappedEndOfNode);
+    const joinPos = joinStep.getMap().map(mappedJoinPos);
 
     transform.insert(joinPos, transform.doc.type.schema.text(ZWSP));
     transform.addMark(
@@ -219,7 +285,10 @@ export function joinNodesAndMarkJoinPoints(
       deletion.create({
         id: markId,
         type: "join",
-        data: { leftNode, rightNode },
+        data: {
+          leftNodes: joinCandidate.leftNodes.map(serializeJoinNode),
+          rightNodes: joinCandidate.rightNodes.map(serializeJoinNode),
+        },
       }),
     );
 
@@ -227,6 +296,87 @@ export function joinNodesAndMarkJoinPoints(
   });
 
   return transform;
+}
+
+function getJoinCandidateAtBoundary(
+  doc: Node,
+  boundaryPos: number,
+  from: number,
+  to: number,
+  maxJoinDepth: number,
+): JoinCandidate | null {
+  const $boundary = doc.resolve(boundaryPos);
+  const leftNode = $boundary.nodeBefore;
+  const rightNode = $boundary.nodeAfter;
+
+  // Multi-depth list joins can begin between structural nodes, not just textblocks.
+  if (!leftNode || !rightNode) return null;
+  if (leftNode.isInline || rightNode.isInline) return null;
+
+  if (!canJoin(doc, boundaryPos)) return null;
+
+  const pairs: JoinPair[] = [{ leftNode, rightNode }];
+
+  for (let expandBy = 1; pairs.length < maxJoinDepth; expandBy += 1) {
+    const left = boundaryPos - expandBy;
+    const right = boundaryPos + expandBy;
+
+    if (left < from || right > to) break;
+
+    const $left = doc.resolve(left);
+    const $right = doc.resolve(right);
+
+    // Once text is adjacent, there is no deeper block pair to capture.
+    if ($left.nodeBefore?.isText || $right.nodeAfter?.isText) break;
+
+    if (
+      $left.nodeAfter === null &&
+      $left.nodeBefore &&
+      !$left.nodeBefore.isInline &&
+      $right.nodeBefore === null &&
+      $right.nodeAfter &&
+      !$right.nodeAfter.isInline
+    ) {
+      pairs.push({
+        leftNode: $left.nodeBefore,
+        rightNode: $right.nodeAfter,
+      });
+      continue;
+    }
+
+    break;
+  }
+
+  // canJoin only checks the boundary; the temporary transform verifies depth.
+  if (!canApplyJoinCandidate(doc, boundaryPos, pairs.length)) return null;
+
+  return {
+    joinPos: boundaryPos,
+    leftNodes: pairs.map((pair) => pair.leftNode).reverse(),
+    rightNodes: pairs.map((pair) => pair.rightNode).reverse(),
+  };
+}
+
+function canApplyJoinCandidate(doc: Node, joinPos: number, depth: number) {
+  if (!canJoin(doc, joinPos)) return false;
+
+  try {
+    new Transform(doc).join(joinPos, depth);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasStructureAddMark(node: Node) {
+  const { structure } = getSuggestionMarks(node.type.schema);
+
+  return node.marks.some((mark) => {
+    if (mark.type !== structure) return false;
+    if (!guardStructureMarkAttrs(mark.attrs)) return false;
+
+    return mark.attrs.data.op.op === "add";
+  });
 }
 
 /**

--- a/src/features/joinOnDelete/normalizeJoinNodesMetadata.ts
+++ b/src/features/joinOnDelete/normalizeJoinNodesMetadata.ts
@@ -1,0 +1,26 @@
+import { isSerializedJoinNode, type JoinMarkAttrs } from "./types.js";
+
+// Block join suggestion metadata/revert currently supports the depth TipTap uses
+// when Backspace joins both list-item paragraphs and their parent list items.
+export const MAX_BLOCK_JOIN_DEPTH = 2;
+
+export function normalizeJoinNodesMetadata(attrs: JoinMarkAttrs) {
+  const data = attrs.data;
+
+  // Normalize legacy metadata so revert can use the same array path.
+  const leftNodes = data.leftNodes ?? (data.leftNode ? [data.leftNode] : null);
+  const rightNodes =
+    data.rightNodes ?? (data.rightNode ? [data.rightNode] : null);
+
+  if (!Array.isArray(leftNodes) || !Array.isArray(rightNodes)) return false;
+  if (leftNodes.length === 0 || leftNodes.length !== rightNodes.length)
+    return false;
+
+  // Reject unsupported depths instead of partially reverting unknown structure.
+  if (leftNodes.length > MAX_BLOCK_JOIN_DEPTH) return false;
+
+  if (!leftNodes.every(isSerializedJoinNode)) return false;
+  if (!rightNodes.every(isSerializedJoinNode)) return false;
+
+  return { leftNodes, rightNodes };
+}

--- a/src/features/joinOnDelete/types.ts
+++ b/src/features/joinOnDelete/types.ts
@@ -1,0 +1,71 @@
+import { type Mark, type Attrs, type Node } from "prosemirror-model";
+import { type SuggestionId } from "../../generateId.js";
+import { getSuggestionMarks } from "../../utils.js";
+
+export interface SerializedJoinNode {
+  type: string;
+  attrs: object;
+  marks: { attrs: Record<string, unknown> }[];
+}
+
+export interface JoinMarkAttrs {
+  id: SuggestionId;
+  type: "join";
+  data: {
+    // Legacy shape from single-depth Block join suggestions.
+    leftNode?: SerializedJoinNode;
+    rightNode?: SerializedJoinNode;
+    // Current child-first shape for multi-depth Block join suggestions.
+    leftNodes?: SerializedJoinNode[];
+    rightNodes?: SerializedJoinNode[];
+  };
+}
+
+export interface JoinPair {
+  leftNode: Node;
+  rightNode: Node;
+}
+
+export interface JoinCandidate {
+  joinPos: number;
+  leftNodes: Node[];
+  rightNodes: Node[];
+}
+
+export function isSerializedJoinNode(
+  node: unknown,
+): node is SerializedJoinNode {
+  if (node === null || typeof node !== "object") return false;
+
+  const data = node as Record<keyof SerializedJoinNode, unknown>;
+  return (
+    typeof data.type === "string" &&
+    typeof data.attrs === "object" &&
+    data.attrs !== null &&
+    Array.isArray(data.marks)
+  );
+}
+
+export function isJoinMarkAttrs(attrs: Attrs): attrs is JoinMarkAttrs {
+  if (typeof attrs["id"] !== "string" && typeof attrs["id"] !== "number") {
+    return false;
+  }
+  if (attrs["type"] !== "join") return false;
+  if (attrs["data"] == null) return false;
+  return true;
+}
+
+export function isJoinMarkObject(
+  mark: unknown,
+): mark is Omit<Mark, "attrs"> & { attrs: JoinMarkAttrs } {
+  if (mark === null || typeof mark !== "object") return false;
+  if (!("attrs" in mark)) return false;
+  return isJoinMarkAttrs(mark.attrs as Attrs);
+}
+
+export function isJoinMark(
+  mark: Mark,
+): mark is Omit<Mark, "attrs"> & { attrs: JoinMarkAttrs } {
+  const { deletion } = getSuggestionMarks(mark.type.schema);
+  return mark.type === deletion && isJoinMarkAttrs(mark.attrs);
+}

--- a/src/features/startToStartTextblockDeletion/index.ts
+++ b/src/features/startToStartTextblockDeletion/index.ts
@@ -14,6 +14,9 @@ export function adjustForStartToStartTextblockDeletion(
     return { from: step.from, to: step.to };
   }
 
+  // ProseMirror can represent a start-to-start textblock selection as a block
+  // boundary deletion. The user-visible deletion ends at the selection head,
+  // not at the start token of the right textblock.
   const { $from, $to } = selection;
   if (!$from.parent.isTextblock || !$to.parent.isTextblock) {
     return { from: step.from, to: step.to };

--- a/src/features/transactionShaping/CONTEXT.md
+++ b/src/features/transactionShaping/CONTEXT.md
@@ -18,3 +18,9 @@ Backspace moves a paragraph into the previous list item and then joins it with
 that list item's paragraph; it is one visible edit expressed through existing
 Structure suggestion and Block join suggestion concepts sharing one suggestion
 ID. _Avoid_: list backspace hack, paragraph absorption
+
+**ProseMirror split-after-selection-delete**: A **Special transaction shape**
+where Enter over a non-empty text selection is emitted as a deletion step
+followed by a structural split step; it is one visible edit expressed through
+normal suggestion tracking rather than Structure suggestion tracking. _Avoid_:
+boundary Enter hack, split false positive

--- a/src/features/transactionShaping/CONTEXT.md
+++ b/src/features/transactionShaping/CONTEXT.md
@@ -1,0 +1,20 @@
+# Transaction Shaping
+
+This context covers recognized compound editor transactions that are rewritten
+into existing tracked suggestion concepts before normal suggestion tracking.
+
+## Language
+
+**Transaction shaping**: Recognition of a known editor transaction shape and its
+expression as existing suggestion concepts rather than a new suggestion type.
+_Avoid_: transaction workaround, custom suggestion
+
+**Special transaction shape**: A concrete multi-step editor transaction pattern
+whose visible edit crosses existing suggestion-context boundaries. _Avoid_:
+weird transaction, keymap quirk
+
+**TipTap paragraph-into-list join**: A **Special transaction shape** where
+Backspace moves a paragraph into the previous list item and then joins it with
+that list item's paragraph; it is one visible edit expressed through existing
+Structure suggestion and Block join suggestion concepts sharing one suggestion
+ID. _Avoid_: list backspace hack, paragraph absorption

--- a/src/features/transactionShaping/detectSpecialTransactionShape.ts
+++ b/src/features/transactionShaping/detectSpecialTransactionShape.ts
@@ -1,9 +1,13 @@
 import { type Transaction } from "prosemirror-state";
+import { detectProseMirrorSplitBlockAfterSelectionDelete } from "./proseMirrorSplitBlockAfterSelectionDelete/index.js";
 import { detectTipTapParagraphIntoListJoin } from "./tipTapParagraphIntoListJoin/detectTipTapParagraphIntoListJoin.js";
 import { type SpecialTransactionShape } from "./types.js";
 
 export function detectSpecialTransactionShape(
   transaction: Transaction,
 ): SpecialTransactionShape | null {
-  return detectTipTapParagraphIntoListJoin(transaction);
+  return (
+    detectProseMirrorSplitBlockAfterSelectionDelete(transaction) ??
+    detectTipTapParagraphIntoListJoin(transaction)
+  );
 }

--- a/src/features/transactionShaping/detectSpecialTransactionShape.ts
+++ b/src/features/transactionShaping/detectSpecialTransactionShape.ts
@@ -1,0 +1,9 @@
+import { type Transaction } from "prosemirror-state";
+import { detectTipTapParagraphIntoListJoin } from "./tipTapParagraphIntoListJoin/detectTipTapParagraphIntoListJoin.js";
+import { type SpecialTransactionShape } from "./types.js";
+
+export function detectSpecialTransactionShape(
+  transaction: Transaction,
+): SpecialTransactionShape | null {
+  return detectTipTapParagraphIntoListJoin(transaction);
+}

--- a/src/features/transactionShaping/docs/adr/0001-tiptap-paragraph-into-list-join.md
+++ b/src/features/transactionShaping/docs/adr/0001-tiptap-paragraph-into-list-join.md
@@ -1,0 +1,74 @@
+# TipTap Paragraph Into List Join Transaction Shaping
+
+TipTap's list keymap emits a three-step transaction when Backspace is pressed at
+the start of a paragraph that immediately follows a list. The visible edit is
+one operation: move the paragraph into the last list item and join it with that
+item's paragraph. The transaction mechanics are more specific:
+
+Step 1 deletes the standalone paragraph after the list:
+
+```json
+{ "stepType": "replace", "from": 42, "to": 60 }
+```
+
+After this step, the document contains only the list. The paragraph text is not
+visible anywhere in the document.
+
+Step 2 inserts the same paragraph into the last list item:
+
+```json
+{
+  "stepType": "replace",
+  "from": 40,
+  "to": 40,
+  "slice": {
+    "content": [
+      {
+        "type": "paragraph",
+        "attrs": {
+          "id": "node-9",
+          "textAlign": null
+        },
+        "content": [{ "type": "text", "text": "sample paragraph" }]
+      }
+    ]
+  }
+}
+```
+
+After this step, the last list item has two paragraphs: the original item
+paragraph and the moved paragraph.
+
+Step 3 joins those two paragraphs inside the last list item:
+
+```json
+{ "stepType": "replace", "from": 39, "to": 41, "structure": true }
+```
+
+After this step, the last list item has one paragraph containing both texts.
+
+Track this transaction as one semantic suggestion represented by two existing
+suggestion concepts rather than inventing new Block join metadata. Generate one
+suggestion id for the shaped transaction and pass a fixed-id generator to both
+tracking paths. Run Structure suggestion tracking on the prefix represented by
+steps 1 and 2. For accepted content, the stable paragraph id produces a
+Structure move suggestion with that shared id. For provisional Structure add
+content, the move is absorbed by the existing Structure add suggestion and
+remains a valid shaped prefix.
+
+Then run normal suggestion tracking on step 3 using the same fixed id. For
+accepted joined nodes, Join on Delete creates an ordinary Block join suggestion
+with the shared id. The Block join metadata already serializes node marks, so
+rejecting the Block join reveals the Structure move suggestion. Single
+suggestion rejection, and the Block join pre-pass used by revert-all, prioritize
+restored Structure suggestions with the same id. This lets the shaped move and
+join reject as one semantic unit before any broader restored-Structure cleanup
+runs. If any joined node still has a Structure add suggestion, provisional add
+join cancellation applies: the physical join happens, but no Block join
+suggestion is created.
+
+This transaction shape is handled in a transaction shaping layer before the
+normal Structure-vs-main tracking branch. If the shape is detected but Structure
+tracking is unavailable, unique IDs cannot be settled, or prefix Structure
+tracking does not handle the move, transaction shaping declines to handle it and
+the existing branch runs unchanged.

--- a/src/features/transactionShaping/docs/adr/0002-prosemirror-split-after-selection-delete.md
+++ b/src/features/transactionShaping/docs/adr/0002-prosemirror-split-after-selection-delete.md
@@ -1,0 +1,18 @@
+# ProseMirror Split After Selection Delete Transaction Shaping
+
+ProseMirror's base Enter command can emit a two-step transaction when Enter is
+pressed over a non-empty text selection: first delete the selected content, then
+perform a structural split at the deletion start. When the selection crosses
+list-item textblock boundaries, the structural split can look like a Structure
+add candidate even though the visible edit is deletion plus split. Route this
+recognized transaction shape through normal suggestion tracking as a whole, so
+the deleted content receives deletion marks and the split receives ordinary
+split-derived insertion marks.
+
+This deliberately avoids disabling Structure add suggestions globally. Structure
+add remains the representation for newly materialized content nodes inside
+tracked structural contexts when they are not recognized as split-derived. It
+also avoids broad before/after text-content inspection; the detector is limited
+to the exact delete-step plus structural-split step shape, with both deletion
+endpoints inside textblock parents and the split slice carrying the duplicated
+stable node id produced by ProseMirror's split.

--- a/src/features/transactionShaping/index.ts
+++ b/src/features/transactionShaping/index.ts
@@ -1,0 +1,22 @@
+import { type Transaction } from "prosemirror-state";
+import { handleTipTapParagraphIntoListJoin } from "./tipTapParagraphIntoListJoin/index.js";
+import { type HandleSpecialTransactionShapeArgs } from "./types.js";
+
+type SpecialTransactionShapeHandler = (
+  args: HandleSpecialTransactionShapeArgs,
+) => Transaction | null;
+
+const specialTransactionShapeHandlers: SpecialTransactionShapeHandler[] = [
+  handleTipTapParagraphIntoListJoin,
+];
+
+export function handleSpecialTransactionShape(
+  args: HandleSpecialTransactionShapeArgs,
+): Transaction | null {
+  for (const handler of specialTransactionShapeHandlers) {
+    const transaction = handler(args);
+    if (transaction) return transaction;
+  }
+
+  return null;
+}

--- a/src/features/transactionShaping/index.ts
+++ b/src/features/transactionShaping/index.ts
@@ -1,4 +1,5 @@
 import { type Transaction } from "prosemirror-state";
+import { handleProseMirrorSplitBlockAfterSelectionDelete } from "./proseMirrorSplitBlockAfterSelectionDelete/index.js";
 import { handleTipTapParagraphIntoListJoin } from "./tipTapParagraphIntoListJoin/index.js";
 import { type HandleSpecialTransactionShapeArgs } from "./types.js";
 
@@ -7,6 +8,10 @@ type SpecialTransactionShapeHandler = (
 ) => Transaction | null;
 
 const specialTransactionShapeHandlers: SpecialTransactionShapeHandler[] = [
+  // Handlers are ordered from most direct fallthrough to partial reshaping.
+  // A whole-transaction main-route escape should claim its shape before any
+  // handler tries to split a compound transaction into structure/main phases.
+  handleProseMirrorSplitBlockAfterSelectionDelete,
   handleTipTapParagraphIntoListJoin,
 ];
 

--- a/src/features/transactionShaping/proseMirrorSplitBlockAfterSelectionDelete/detectProseMirrorSplitBlockAfterSelectionDelete.test.ts
+++ b/src/features/transactionShaping/proseMirrorSplitBlockAfterSelectionDelete/detectProseMirrorSplitBlockAfterSelectionDelete.test.ts
@@ -1,0 +1,115 @@
+import { EditorState } from "prosemirror-state";
+import { Step } from "prosemirror-transform";
+import { describe, expect, it } from "vitest";
+import { createSchema } from "../../../testing/e2eTestSchema.js";
+import { detectProseMirrorSplitBlockAfterSelectionDelete } from "./detectProseMirrorSplitBlockAfterSelectionDelete.js";
+
+const schema = createSchema();
+
+const LIST_BOUNDARY_DOC = {
+  type: "doc",
+  content: [
+    {
+      type: "orderedList",
+      attrs: { id: "node-0" },
+      content: [1, 2, 3, 4, 5].map((index) => ({
+        type: "listItem",
+        attrs: { id: `node-${String(index * 2 - 1)}` },
+        content: [
+          {
+            type: "paragraph",
+            attrs: { id: `node-${String(index * 2)}` },
+            content: [{ type: "text", text: `Item ${String(index)}` }],
+          },
+        ],
+      })),
+    },
+  ],
+};
+
+const DELETE_STEP = { stepType: "replace", from: 17, to: 27 };
+
+const SPLIT_STEP = {
+  stepType: "replace",
+  from: 17,
+  to: 17,
+  slice: {
+    content: [
+      { type: "paragraph", attrs: { id: "node-4" } },
+      { type: "paragraph", attrs: { id: "node-4" } },
+    ],
+    openStart: 1,
+    openEnd: 1,
+  },
+  structure: true,
+};
+
+function createTransaction(stepsJSON: object[]) {
+  const doc = schema.nodeFromJSON(LIST_BOUNDARY_DOC);
+  const transaction = EditorState.create({ doc }).tr;
+
+  stepsJSON.forEach((stepJSON) => {
+    transaction.step(Step.fromJSON(schema, stepJSON));
+  });
+
+  return transaction;
+}
+
+describe("detectProseMirrorSplitBlockAfterSelectionDelete", () => {
+  it("detects ProseMirror's deleteSelection plus splitBlock transaction shape", () => {
+    const transaction = createTransaction([DELETE_STEP, SPLIT_STEP]);
+
+    const shape = detectProseMirrorSplitBlockAfterSelectionDelete(transaction);
+
+    expect(shape).toMatchObject({
+      type: "proseMirrorSplitBlockAfterSelectionDelete",
+      deleteStep: {
+        from: 17,
+        to: 27,
+      },
+      splitStep: {
+        from: 17,
+        to: 17,
+      },
+    });
+  });
+
+  it("rejects the deletion half by itself", () => {
+    const transaction = createTransaction([DELETE_STEP]);
+
+    expect(detectProseMirrorSplitBlockAfterSelectionDelete(transaction)).toBe(
+      null,
+    );
+  });
+
+  it("rejects a split step that is not structural", () => {
+    const transaction = createTransaction([
+      DELETE_STEP,
+      { ...SPLIT_STEP, structure: false },
+    ]);
+
+    expect(detectProseMirrorSplitBlockAfterSelectionDelete(transaction)).toBe(
+      null,
+    );
+  });
+
+  it("rejects split children without a shared node id", () => {
+    const transaction = createTransaction([
+      DELETE_STEP,
+      {
+        ...SPLIT_STEP,
+        slice: {
+          ...SPLIT_STEP.slice,
+          content: [
+            { type: "paragraph", attrs: { id: "node-4" } },
+            { type: "paragraph", attrs: { id: "node-5" } },
+          ],
+        },
+      },
+    ]);
+
+    expect(detectProseMirrorSplitBlockAfterSelectionDelete(transaction)).toBe(
+      null,
+    );
+  });
+});

--- a/src/features/transactionShaping/proseMirrorSplitBlockAfterSelectionDelete/detectProseMirrorSplitBlockAfterSelectionDelete.ts
+++ b/src/features/transactionShaping/proseMirrorSplitBlockAfterSelectionDelete/detectProseMirrorSplitBlockAfterSelectionDelete.ts
@@ -1,0 +1,85 @@
+import { type Transaction } from "prosemirror-state";
+import { ReplaceStep, Transform } from "prosemirror-transform";
+import { getNodeId } from "../../wrapUnwrap/getNodeId.js";
+import { type ProseMirrorSplitBlockAfterSelectionDeleteShape } from "../types.js";
+
+/**
+ * Detect a Transaction of a certain shape
+ * The shape that occurs when there is a non empty selection across multiple nodes,
+ * followed by an Enter keypress
+ *
+ * A two-step transaction is produced - first step deletes the selection,
+ * second step splits the final selection-containing node
+ *
+ * That second split triggers the structure tracking code path - not the main code path
+ * which causes the selection deletion to be lost in time
+ *
+ * So we bail this transaction shape out of the structure tracking,
+ * and let the main code path handle it with deletion + insertion marks
+ *
+ * @param transaction
+ * @returns
+ */
+export function detectProseMirrorSplitBlockAfterSelectionDelete(
+  transaction: Transaction,
+): ProseMirrorSplitBlockAfterSelectionDeleteShape | null {
+  // a 2-step transaction
+  if (transaction.steps.length !== 2) return null;
+
+  const [deleteStep, splitStep] = transaction.steps;
+  if (
+    !(deleteStep instanceof ReplaceStep) ||
+    !(splitStep instanceof ReplaceStep)
+  ) {
+    return null;
+  }
+
+  // non-empty deletion step
+  if (deleteStep.from >= deleteStep.to) return null;
+  if (deleteStep.slice.content.size !== 0) return null;
+  if (hasStructureFlag(deleteStep)) return null;
+
+  // there is a docBefore, and step boundaries are in the different textblocks
+  const docBefore = transaction.docs[0];
+  if (!docBefore) return null;
+
+  if (!docBefore.resolve(deleteStep.from).parent.isTextblock) return null;
+  if (!docBefore.resolve(deleteStep.to).parent.isTextblock) return null;
+
+  // non empty split step
+  if (splitStep.from !== splitStep.to) return null;
+  // split step happens at the deletion step "from"
+  if (splitStep.from !== deleteStep.from) return null;
+  if (!hasStructureFlag(splitStep)) return null;
+  if (splitStep.slice.openStart !== 1 || splitStep.slice.openEnd !== 1) {
+    return null;
+  }
+  if (splitStep.slice.content.childCount !== 2) return null;
+
+  const leftSplitChild = splitStep.slice.content.child(0);
+  const rightSplitChild = splitStep.slice.content.child(1);
+  if (!leftSplitChild.isTextblock || !rightSplitChild.isTextblock) return null;
+
+  const leftSplitChildId = getNodeId(leftSplitChild);
+  if (!leftSplitChildId || getNodeId(rightSplitChild) !== leftSplitChildId) {
+    return null;
+  }
+
+  try {
+    const preview = new Transform(docBefore);
+    preview.step(deleteStep);
+    preview.step(splitStep);
+  } catch {
+    return null;
+  }
+
+  return {
+    type: "proseMirrorSplitBlockAfterSelectionDelete",
+    deleteStep,
+    splitStep,
+  };
+}
+
+function hasStructureFlag(step: ReplaceStep) {
+  return (step as ReplaceStep & { structure?: boolean }).structure === true;
+}

--- a/src/features/transactionShaping/proseMirrorSplitBlockAfterSelectionDelete/handleProseMirrorSplitBlockAfterSelectionDelete.ts
+++ b/src/features/transactionShaping/proseMirrorSplitBlockAfterSelectionDelete/handleProseMirrorSplitBlockAfterSelectionDelete.ts
@@ -1,0 +1,21 @@
+import { type Transaction } from "prosemirror-state";
+import { transformToSuggestionTransaction } from "../../../transformToSuggestionTransaction.js";
+import { type HandleSpecialTransactionShapeArgs } from "../types.js";
+import { detectProseMirrorSplitBlockAfterSelectionDelete } from "./detectProseMirrorSplitBlockAfterSelectionDelete.js";
+
+export function handleProseMirrorSplitBlockAfterSelectionDelete(
+  args: HandleSpecialTransactionShapeArgs,
+): Transaction | null {
+  if (!detectProseMirrorSplitBlockAfterSelectionDelete(args.transaction)) {
+    return null;
+  }
+
+  // Unlike the TipTap join shape, both steps belong to the main suggestion
+  // route: deletion marks preserve the selected content, and split handling
+  // marks the created split side. Structure tracking would drop the deletion.
+  return transformToSuggestionTransaction(
+    args.transaction,
+    args.state,
+    args.generateId,
+  );
+}

--- a/src/features/transactionShaping/proseMirrorSplitBlockAfterSelectionDelete/index.ts
+++ b/src/features/transactionShaping/proseMirrorSplitBlockAfterSelectionDelete/index.ts
@@ -1,0 +1,2 @@
+export { detectProseMirrorSplitBlockAfterSelectionDelete } from "./detectProseMirrorSplitBlockAfterSelectionDelete.js";
+export { handleProseMirrorSplitBlockAfterSelectionDelete } from "./handleProseMirrorSplitBlockAfterSelectionDelete.js";

--- a/src/features/transactionShaping/tipTapParagraphIntoListJoin/detectTipTapParagraphIntoListJoin.test.ts
+++ b/src/features/transactionShaping/tipTapParagraphIntoListJoin/detectTipTapParagraphIntoListJoin.test.ts
@@ -1,0 +1,176 @@
+import { EditorState } from "prosemirror-state";
+import { Step } from "prosemirror-transform";
+import { describe, expect, it } from "vitest";
+import { createSchema } from "../../../testing/e2eTestSchema.js";
+import { detectTipTapParagraphIntoListJoin } from "./detectTipTapParagraphIntoListJoin.js";
+
+const schema = createSchema();
+
+// when joining a paragraph into a list above it,
+// TipTap List extension overrides the default ProseMirror behavior
+// by default, ProseMirror puts the paragraph to the end of list as a separate list item
+// TipTap instead joins the paragraph with the paragraph of the last list item
+const TIPTAP_PARAGRAPH_INTO_LIST_STEPS = [
+  // first step deletes the paragraph that we're joining
+  { stepType: "replace", from: 42, to: 60 },
+  // second step inserts that paragraph into the last list item
+  {
+    stepType: "replace",
+    from: 40,
+    to: 40,
+    slice: {
+      content: [
+        {
+          type: "paragraph",
+          attrs: { id: "node-9", textAlign: null },
+          content: [{ type: "text", text: "sample paragraph" }],
+        },
+      ],
+    },
+  },
+  // third step joins the two paragraphs in the list item
+  { stepType: "replace", from: 39, to: 41, structure: true },
+];
+
+const TIPTAP_PARAGRAPH_INTO_LIST_DOC = {
+  type: "doc",
+  content: [
+    {
+      type: "orderedList",
+      attrs: {
+        order: 1,
+        id: "node-0",
+      },
+      content: [
+        {
+          type: "listItem",
+          attrs: {
+            id: "node-1",
+          },
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-2",
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Item 1",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "listItem",
+          attrs: {
+            id: "node-3",
+          },
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-4",
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Item 2",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "listItem",
+          attrs: {
+            id: "node-5",
+          },
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-6",
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Item 3",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "listItem",
+          attrs: {
+            id: "node-7",
+          },
+          content: [
+            {
+              type: "paragraph",
+              attrs: {
+                id: "node-8",
+              },
+              content: [
+                {
+                  type: "text",
+                  text: "Item 4",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: "paragraph",
+      attrs: {
+        id: "node-9",
+      },
+      content: [
+        {
+          type: "text",
+          text: "sample paragraph",
+        },
+      ],
+    },
+  ],
+};
+
+describe("detectTipTapParagraphIntoListJoin", () => {
+  it("detects TipTap's three-step paragraph-into-list join shape", () => {
+    const doc = schema.nodeFromJSON(TIPTAP_PARAGRAPH_INTO_LIST_DOC);
+    const state = EditorState.create({ doc });
+    const transaction = state.tr;
+
+    TIPTAP_PARAGRAPH_INTO_LIST_STEPS.forEach((stepJSON) => {
+      transaction.step(Step.fromJSON(schema, stepJSON));
+    });
+
+    const shape = detectTipTapParagraphIntoListJoin(transaction);
+
+    expect(shape).toMatchObject({
+      type: "tipTapParagraphIntoListJoin",
+      deleteStep: {
+        from: 42,
+        to: 60,
+      },
+      insertStep: {
+        from: 40,
+        to: 40,
+      },
+      joinStep: {
+        from: 39,
+        to: 41,
+      },
+      movedNode: {
+        attrs: {
+          id: "node-9",
+        },
+      },
+    });
+    expect(shape?.movedNode.textContent).toBe("sample paragraph");
+  });
+});

--- a/src/features/transactionShaping/tipTapParagraphIntoListJoin/detectTipTapParagraphIntoListJoin.ts
+++ b/src/features/transactionShaping/tipTapParagraphIntoListJoin/detectTipTapParagraphIntoListJoin.ts
@@ -1,0 +1,76 @@
+import { type Transaction } from "prosemirror-state";
+import { ReplaceStep, Transform } from "prosemirror-transform";
+import { getNodeId } from "../../wrapUnwrap/getNodeId.js";
+import { type TipTapParagraphIntoListJoinShape } from "../types.js";
+
+// detect a very specific TipTap pattern where joining a paragraph into a list above it
+// causes a 3-step transaction, which is different from normal prosemirror where you just get 1 step
+// see unit test for details
+export function detectTipTapParagraphIntoListJoin(
+  transaction: Transaction,
+): TipTapParagraphIntoListJoinShape | null {
+  if (transaction.steps.length !== 3) return null;
+
+  const [deleteStep, insertStep, joinStep] = transaction.steps;
+  if (
+    !(deleteStep instanceof ReplaceStep) ||
+    !(insertStep instanceof ReplaceStep) ||
+    !(joinStep instanceof ReplaceStep)
+  ) {
+    return null;
+  }
+
+  if (deleteStep.slice.content.size !== 0) return null;
+  if (insertStep.from !== insertStep.to) return null;
+  if (insertStep.slice.openStart !== 0 || insertStep.slice.openEnd !== 0)
+    return null;
+  if (insertStep.slice.content.childCount !== 1) return null;
+  if (joinStep.slice.content.size !== 0) return null;
+  if ((joinStep as ReplaceStep & { structure?: boolean }).structure !== true)
+    return null;
+
+  const docBefore = transaction.docs[0];
+  if (!docBefore) return null;
+
+  const movedNode = docBefore.nodeAt(deleteStep.from);
+  if (
+    !movedNode ||
+    !movedNode.isTextblock ||
+    movedNode.nodeSize !== deleteStep.to - deleteStep.from
+  ) {
+    return null;
+  }
+
+  const insertedNode = insertStep.slice.content.firstChild;
+  if (!insertedNode?.isTextblock) return null;
+  if (insertedNode.type !== movedNode.type) return null;
+  if (insertedNode.textContent !== movedNode.textContent) return null;
+
+  const movedNodeId = getNodeId(movedNode);
+  if (!movedNodeId || getNodeId(insertedNode) !== movedNodeId) return null;
+
+  const previousSibling = docBefore.resolve(deleteStep.from).nodeBefore;
+  if (!previousSibling || previousSibling.isInline) return null;
+
+  try {
+    const preview = new Transform(docBefore);
+    preview.step(deleteStep);
+    preview.step(insertStep);
+    new Transform(preview.doc).step(joinStep);
+  } catch {
+    return null;
+  }
+
+  console.warn(
+    "[prosemirror-suggest-changes]",
+    "detected TipTap paragraph into list join shape",
+  );
+
+  return {
+    type: "tipTapParagraphIntoListJoin",
+    deleteStep,
+    insertStep,
+    joinStep,
+    movedNode,
+  };
+}

--- a/src/features/transactionShaping/tipTapParagraphIntoListJoin/handleTipTapParagraphIntoListJoin.ts
+++ b/src/features/transactionShaping/tipTapParagraphIntoListJoin/handleTipTapParagraphIntoListJoin.ts
@@ -1,0 +1,117 @@
+import { EditorState, Selection, type Transaction } from "prosemirror-state";
+import {
+  preserveTransactionData,
+  transformToSuggestionTransaction,
+} from "../../../transformToSuggestionTransaction.js";
+import { generateNextNumberId } from "../../../generateId.js";
+import { suggestStructureChanges } from "../../wrapUnwrap/structureChangesPlugin.js";
+import { detectSpecialTransactionShape } from "../detectSpecialTransactionShape.js";
+import {
+  type HandleSpecialTransactionShapeArgs,
+  type SpecialTransactionShape,
+  type TipTapParagraphIntoListJoinShape,
+} from "../types.js";
+
+// handle the specific TipTap pattern when backspacing from a paragraph into a list above
+// causes a transaction with 3 steps
+// "slice" the transaction into two pieces, first piece is the first 2 steps, second piece is the last step
+// first piece "moves" the paragraph - handled by structure change tracking - a structure "move" suggestion
+// second piece joins two paragraphs - handled by the main plugin join-on-delete feature - deletion type="join" mark
+export function handleTipTapParagraphIntoListJoin(
+  args: HandleSpecialTransactionShapeArgs,
+): Transaction | null {
+  const shape = detectSpecialTransactionShape(args.transaction);
+  if (!isTipTapParagraphIntoListJoinShape(shape)) return null;
+
+  if (!args.structuralContextPaths || !args.ensureUniqueNodeIds) return null;
+
+  const docBefore = args.transaction.docs[0];
+  if (!docBefore) return null;
+
+  const trackedTransaction = args.state.tr;
+  const sharedSuggestionId = args.generateId
+    ? args.generateId(args.state.schema, docBefore)
+    : generateNextNumberId(args.state.schema, docBefore);
+  const generateSharedSuggestionId = () => sharedSuggestionId;
+
+  try {
+    trackedTransaction.step(shape.deleteStep);
+    trackedTransaction.step(shape.insertStep);
+  } catch {
+    return null;
+  }
+
+  const uniqueNodeIdsTransform = args.ensureUniqueNodeIds(
+    [args.transaction],
+    docBefore,
+    trackedTransaction.doc,
+  );
+
+  uniqueNodeIdsTransform.steps.forEach((step) => {
+    trackedTransaction.step(step);
+  });
+
+  const structureChangesResult = suggestStructureChanges(
+    docBefore,
+    uniqueNodeIdsTransform.doc,
+    args.structuralContextPaths,
+    generateSharedSuggestionId,
+  );
+
+  if (!structureChangesResult.handled) {
+    return null;
+  }
+
+  structureChangesResult.transform.steps.forEach((step) => {
+    trackedTransaction.step(step);
+  });
+
+  const intermediateState = EditorState.create({
+    schema: args.state.schema,
+    doc: trackedTransaction.doc,
+  });
+  const joinTransaction = intermediateState.tr;
+
+  try {
+    joinTransaction.step(shape.joinStep);
+  } catch {
+    return null;
+  }
+
+  const trackedJoinTransaction = transformToSuggestionTransaction(
+    joinTransaction,
+    intermediateState,
+    generateSharedSuggestionId,
+  );
+
+  trackedJoinTransaction.steps.forEach((step) => {
+    trackedTransaction.step(step);
+  });
+
+  preserveTransactionData(trackedTransaction, trackedJoinTransaction, {
+    selection: false,
+    preserveScroll: false,
+    preserveStoredMarks: false,
+    preserveMeta: false,
+  });
+  preserveTransactionData(trackedTransaction, args.transaction, {
+    selection: false,
+  });
+
+  if (args.transaction.selectionSet) {
+    trackedTransaction.setSelection(
+      Selection.fromJSON(
+        trackedTransaction.doc,
+        args.transaction.selection.toJSON(),
+      ),
+    );
+  }
+
+  return trackedTransaction;
+}
+
+function isTipTapParagraphIntoListJoinShape(
+  shape: SpecialTransactionShape | null,
+): shape is TipTapParagraphIntoListJoinShape {
+  return shape?.type === "tipTapParagraphIntoListJoin";
+}

--- a/src/features/transactionShaping/tipTapParagraphIntoListJoin/index.ts
+++ b/src/features/transactionShaping/tipTapParagraphIntoListJoin/index.ts
@@ -1,0 +1,2 @@
+export { detectTipTapParagraphIntoListJoin } from "./detectTipTapParagraphIntoListJoin.js";
+export { handleTipTapParagraphIntoListJoin } from "./handleTipTapParagraphIntoListJoin.js";

--- a/src/features/transactionShaping/types.ts
+++ b/src/features/transactionShaping/types.ts
@@ -12,7 +12,15 @@ export interface TipTapParagraphIntoListJoinShape {
   movedNode: Node;
 }
 
-export type SpecialTransactionShape = TipTapParagraphIntoListJoinShape;
+export interface ProseMirrorSplitBlockAfterSelectionDeleteShape {
+  type: "proseMirrorSplitBlockAfterSelectionDelete";
+  deleteStep: ReplaceStep;
+  splitStep: ReplaceStep;
+}
+
+export type SpecialTransactionShape =
+  | TipTapParagraphIntoListJoinShape
+  | ProseMirrorSplitBlockAfterSelectionDeleteShape;
 
 export interface HandleSpecialTransactionShapeArgs {
   transaction: Transaction;

--- a/src/features/transactionShaping/types.ts
+++ b/src/features/transactionShaping/types.ts
@@ -1,0 +1,25 @@
+import { type Node, type Schema } from "prosemirror-model";
+import { type EditorState, type Transaction } from "prosemirror-state";
+import { type ReplaceStep, type Transform } from "prosemirror-transform";
+import { type SuggestionId } from "../../generateId.js";
+import { type StructuralContextPath } from "../wrapUnwrap/types.js";
+
+export interface TipTapParagraphIntoListJoinShape {
+  type: "tipTapParagraphIntoListJoin";
+  deleteStep: ReplaceStep;
+  insertStep: ReplaceStep;
+  joinStep: ReplaceStep;
+  movedNode: Node;
+}
+
+export type SpecialTransactionShape = TipTapParagraphIntoListJoinShape;
+
+export interface HandleSpecialTransactionShapeArgs {
+  transaction: Transaction;
+  state: EditorState;
+  generateId: ((schema: Schema, doc?: Node) => SuggestionId) | undefined;
+  structuralContextPaths: StructuralContextPath[] | null;
+  ensureUniqueNodeIds:
+    | ((transactions: Transaction[], oldDoc: Node, newDoc: Node) => Transform)
+    | undefined;
+}

--- a/src/features/wrapUnwrap/CONTEXT.md
+++ b/src/features/wrapUnwrap/CONTEXT.md
@@ -7,8 +7,8 @@ blockquotes.
 ## Language
 
 **Structure suggestion**: One semantic structural context change represented by
-one or more **Structure marks** sharing the same suggestion ID. _Avoid_: wrapper
-change, tree diff
+one or more **Structure mark** instances sharing the same suggestion ID.
+_Avoid_: wrapper change, tree diff
 
 **Structure mark**: A node-level mark representing either a `move` of the marked
 node from one subtree to another, or an `add` when the marked node did not
@@ -20,8 +20,8 @@ not **Structure mark** targets. _Avoid_: structure alias, wrapper path
 
 **Structure add suggestion**: A provisional **Structure suggestion** for new
 structure that can be moved freely until accepted and does not produce
-**Structure move suggestions** while provisional. _Avoid_: inserted list item,
-pending move
+**Structure move suggestion** instances while provisional. _Avoid_: inserted
+list item, pending move
 
 **Provisional add join cancellation**: A block join where any joined node
 already has a **Structure add suggestion**; the join is performed, but no
@@ -33,14 +33,14 @@ came from splitting an accepted sibling, not a sibling that is still a
 **Structure add suggestion**. _Avoid_: structure add, new list item
 
 **Structure move suggestion**: A **Structure suggestion** for relocating
-accepted content between **Parent chains** when either chain is a direct child
-of a configured **Structural context path**; **Inverse moves** cancel, while
-non-cancelling moves can stack. _Avoid_: indent mark, outdent mark
+accepted content between **Parent chain** values when either chain is a direct
+child of a configured **Structural context path**; **Inverse move** pairs
+cancel, while non-cancelling moves can stack. _Avoid_: indent mark, outdent mark
 
 **Parent chain**: The ordered ancestor chain that locates content within the
 document structure, compared by stable parent node IDs. _Avoid_: document
 position, DOM path
 
-**Inverse move**: A pair of **Structure move suggestions** where each move's
-source **Parent chain** equals the other move's destination **Parent chain**.
-_Avoid_: undo mark, reverse mark
+**Inverse move**: A pair of **Structure move suggestion** instances where each
+move's source **Parent chain** equals the other move's destination **Parent
+chain**. _Avoid_: undo mark, reverse mark

--- a/src/features/wrapUnwrap/CONTEXT.md
+++ b/src/features/wrapUnwrap/CONTEXT.md
@@ -1,0 +1,46 @@
+# Wrap/Unwrap Structure Suggestions
+
+This context covers tracked suggestions for configured structural context edits,
+such as indenting, outdenting, wrapping, and unwrapping content inside lists or
+blockquotes.
+
+## Language
+
+**Structure suggestion**: One semantic structural context change represented by
+one or more **Structure marks** sharing the same suggestion ID. _Avoid_: wrapper
+change, tree diff
+
+**Structure mark**: A node-level mark representing either a `move` of the marked
+node from one subtree to another, or an `add` when the marked node did not
+previously exist in the document. _Avoid_: wrapper mark, list mark
+
+**Structural context path**: A configured contiguous parent-child ancestor path
+of ProseMirror node type names whose nodes provide structural context but are
+not **Structure mark** targets. _Avoid_: structure alias, wrapper path
+
+**Structure add suggestion**: A provisional **Structure suggestion** for new
+structure that can be moved freely until accepted and does not produce
+**Structure move suggestions** while provisional. _Avoid_: inserted list item,
+pending move
+
+**Provisional add join cancellation**: A block join where any joined node
+already has a **Structure add suggestion**; the join is performed, but no
+separate **Block join suggestion** is created. _Avoid_: provisional join mark,
+add deletion
+
+**Split-derived content node**: A newly materialized content node whose text
+came from splitting an accepted sibling, not a sibling that is still a
+**Structure add suggestion**. _Avoid_: structure add, new list item
+
+**Structure move suggestion**: A **Structure suggestion** for relocating
+accepted content between **Parent chains** when either chain is a direct child
+of a configured **Structural context path**; **Inverse moves** cancel, while
+non-cancelling moves can stack. _Avoid_: indent mark, outdent mark
+
+**Parent chain**: The ordered ancestor chain that locates content within the
+document structure, compared by stable parent node IDs. _Avoid_: document
+position, DOM path
+
+**Inverse move**: A pair of **Structure move suggestions** where each move's
+source **Parent chain** equals the other move's destination **Parent chain**.
+_Avoid_: undo mark, reverse mark

--- a/src/features/wrapUnwrap/CONTEXT.md
+++ b/src/features/wrapUnwrap/CONTEXT.md
@@ -12,7 +12,17 @@ _Avoid_: wrapper change, tree diff
 
 **Structure mark**: A node-level mark representing either a `move` of the marked
 node from one subtree to another, or an `add` when the marked node did not
-previously exist in the document. _Avoid_: wrapper mark, list mark
+previously exist in the document, with an effective role in the **Structure
+suggestion**. _Avoid_: wrapper mark, list mark
+
+**Primary Structure mark**: A **Structure mark** whose effective role is the
+user-visible source for a **Structure suggestion**; role-less marks are primary.
+_Avoid_: visible structure mark, main mark
+
+**Supporting Structure mark**: A **Structure mark** whose effective role is
+bookkeeping for collateral structural movement inside the same **Structure
+suggestion**, not a user-visible review source. _Avoid_: hidden structure mark,
+secondary mark
 
 **Structural context path**: A configured contiguous parent-child ancestor path
 of ProseMirror node type names whose nodes provide structural context but are

--- a/src/features/wrapUnwrap/__tests__/blockquoteStructure.playwright.test.ts
+++ b/src/features/wrapUnwrap/__tests__/blockquoteStructure.playwright.test.ts
@@ -1,0 +1,250 @@
+import { test, expect } from "../../../__tests__/playwrightBaseTest.js";
+import { setupDocFromJSON } from "../../../__tests__/playwrightHelpers.js";
+import { EditorPage } from "../../../__tests__/playwrightPage.js";
+import { eq } from "prosemirror-test-builder";
+import {
+  guardStructureAddMarkAttrs,
+  guardStructureMarkObject,
+  guardStructureMoveMarkAttrs,
+} from "../types.js";
+
+const paragraphDoc = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "Paragraph One" }],
+    },
+  ],
+};
+
+const blockquoteDoc = {
+  type: "doc",
+  content: [
+    {
+      type: "blockquote",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Quote One" }],
+        },
+      ],
+    },
+  ],
+};
+
+test.describe("Structure changes in blockquotes", () => {
+  test("Revert a single blockquote wrap", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, paragraphDoc);
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    await page.keyboard.press("ControlOrMeta+U");
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Apply a single blockquote wrap", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Quote One" }],
+        },
+      ],
+    });
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+    await page.keyboard.press("ControlOrMeta+U");
+
+    await editorPage.applyAll();
+
+    const docs = await editorPage.getCurrentAndExpectedDoc({
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          attrs: { id: "node-2" },
+          content: [
+            {
+              type: "paragraph",
+              attrs: { id: "node-1" },
+              content: [{ type: "text", text: "Quote One" }],
+            },
+          ],
+        },
+      ],
+    });
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Unwrapping a previously wrapped paragraph cancels the inverse move", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, paragraphDoc);
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    await page.keyboard.press("ControlOrMeta+U");
+    await page.keyboard.press("ControlOrMeta+L");
+
+    const docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("A new child node added to an existing blockquote with another node structure add mark", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, blockquoteDoc);
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+    await page.keyboard.press("Enter");
+
+    const structureMarks = (await editorPage.getProseMirrorMarksJSON()).filter(
+      guardStructureMarkObject,
+    );
+    expect(structureMarks).toHaveLength(1);
+    expect(
+      structureMarks[0] && guardStructureAddMarkAttrs(structureMarks[0].attrs),
+    ).toBe(true);
+  });
+
+  test("Nesting blockquotes marks the paragraph, not the blockquotes, and can be reverted", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, paragraphDoc);
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    await page.keyboard.press("ControlOrMeta+U");
+    expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+
+    await page.keyboard.press("ControlOrMeta+U");
+    expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(2);
+
+    const structureMarkNodeTypes = await page.evaluate(() => {
+      const nodeTypes: string[] = [];
+      const { structure } = window.pmEditor.view.state.schema.marks;
+      window.pmEditor.view.state.doc.descendants((node) => {
+        if (node.marks.some((mark) => mark.type === structure)) {
+          nodeTypes.push(node.type.name);
+        }
+      });
+      return nodeTypes;
+    });
+    expect(structureMarkNodeTypes).toEqual(["paragraph"]);
+
+    await editorPage.revertAll();
+
+    const docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Revert an indented list item inside a blockquote", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "orderedList",
+              content: [
+                {
+                  type: "listItem",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Quote item 1" }],
+                    },
+                  ],
+                },
+                {
+                  type: "listItem",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Quote item 2" }],
+                    },
+                  ],
+                },
+                {
+                  type: "listItem",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [{ type: "text", text: "Quote item 3" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // Move from Quote item 3 to Quote item 2, then indent Quote item 2 under Quote item 1.
+    await page.keyboard.press("ArrowUp");
+    await page.keyboard.press("Tab");
+
+    const structureMarks = (await editorPage.getProseMirrorMarksJSON()).filter(
+      guardStructureMarkObject,
+    );
+    expect(structureMarks).toHaveLength(1);
+    expect(
+      structureMarks[0] && guardStructureMoveMarkAttrs(structureMarks[0].attrs),
+    ).toBe(true);
+
+    await editorPage.revertAll();
+
+    const docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+});

--- a/src/features/wrapUnwrap/__tests__/boundarySelectionRevert.playwright.test.ts
+++ b/src/features/wrapUnwrap/__tests__/boundarySelectionRevert.playwright.test.ts
@@ -1,0 +1,153 @@
+import { test, expect } from "../../../__tests__/playwrightBaseTest.js";
+import { setupDocFromJSON } from "../../../__tests__/playwrightHelpers.js";
+import { EditorPage } from "../../../__tests__/playwrightPage.js";
+import { eq } from "prosemirror-test-builder";
+import type { Page } from "@playwright/test";
+
+const listBoundaryDoc = {
+  type: "doc",
+  content: [
+    {
+      type: "orderedList",
+      content: [1, 2, 3, 4, 5].map((index) => ({
+        type: "listItem",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: `Item ${String(index)}` }],
+          },
+        ],
+      })),
+    },
+  ],
+};
+
+const enterBoundaryDeleteStep = { stepType: "replace", from: 17, to: 27 };
+
+const enterBoundarySplitStep = {
+  stepType: "replace",
+  from: 17,
+  to: 17,
+  slice: {
+    content: [
+      { type: "paragraph", attrs: { id: "node-4" } },
+      { type: "paragraph", attrs: { id: "node-4" } },
+    ],
+    openStart: 1,
+    openEnd: 1,
+  },
+  structure: true,
+};
+
+const enterAfterListBoundarySelectionSteps = [
+  enterBoundaryDeleteStep,
+  enterBoundarySplitStep,
+];
+
+async function setupListBoundaryDoc(page: Page) {
+  await setupDocFromJSON(page, listBoundaryDoc);
+  await page.evaluate(() => {
+    window.pmEditor.setCursorToEnd();
+  });
+}
+
+async function dispatchRawSteps(page: Page, steps: object[]) {
+  await page.evaluate((steps) => {
+    window.pmEditor.dispatchTransactionWithSteps(steps);
+  }, steps);
+}
+
+async function expectRevertAllRestoresInitialDoc(
+  editorPage: EditorPage,
+  docJSON: object,
+) {
+  let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+  expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+  await editorPage.revertAll();
+
+  docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+  expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+}
+
+test.describe("Structure changes with boundary selections", () => {
+  test("Revert all after pressing Enter on a list boundary selection", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupListBoundaryDoc(page);
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // Move to Item 3, then select from the "Item| 3" boundary up to Item 2.
+    await page.evaluate(() => {
+      let item3Boundary: number | undefined;
+      window.pmEditor.view.state.doc.descendants((node, pos) => {
+        if (item3Boundary !== undefined || !node.isTextblock) return true;
+        if (node.textContent !== "Item 3") return true;
+
+        item3Boundary = pos + "Item".length + 1;
+        return false;
+      });
+
+      if (item3Boundary === undefined) {
+        throw new Error("Could not find Item 3");
+      }
+
+      window.pmEditor.setCursorToPosition(item3Boundary);
+      window.pmEditor.view.focus();
+    });
+
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("ArrowUp");
+    await page.keyboard.up("Shift");
+
+    await page.keyboard.press("Enter");
+
+    await expectRevertAllRestoresInitialDoc(editorPage, docJSON);
+  });
+
+  test("Revert all after dispatching only the deletion half of list boundary Enter", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupListBoundaryDoc(page);
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    await dispatchRawSteps(page, [enterBoundaryDeleteStep]);
+
+    await expectRevertAllRestoresInitialDoc(editorPage, docJSON);
+  });
+
+  test("Revert all after dispatching list boundary Enter steps separately", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupListBoundaryDoc(page);
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    await dispatchRawSteps(page, [enterBoundaryDeleteStep]);
+    await dispatchRawSteps(page, [enterBoundarySplitStep]);
+
+    await expectRevertAllRestoresInitialDoc(editorPage, docJSON);
+  });
+
+  test("Revert all after dispatching list boundary Enter steps together", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupListBoundaryDoc(page);
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    await dispatchRawSteps(page, enterAfterListBoundarySelectionSteps);
+
+    await expectRevertAllRestoresInitialDoc(editorPage, docJSON);
+  });
+});

--- a/src/features/wrapUnwrap/__tests__/boundarySelectionSuccessfulCases.md
+++ b/src/features/wrapUnwrap/__tests__/boundarySelectionSuccessfulCases.md
@@ -1,0 +1,103 @@
+# Boundary Selection Cases That Round-Tripped
+
+These are exploratory wrap/unwrap structure tracking cases tried while looking
+for a failing `initial doc -> operations -> Revert all -> initial doc` scenario.
+They succeeded, so future investigation should not start by repeating them
+unless the behavior changes or we decide to promote them to regression tests.
+
+All cases used real keyboard interactions in the Playwright demo editor and
+ended with `Revert all` producing a document equal to the initial document.
+
+## Top-Level Ordered List
+
+Initial document unless noted otherwise:
+
+```text
+1. Item 1
+2. Item 2
+3. Item 3
+4. Item 4
+```
+
+- Select adjacent items at a text boundary, indent with `Tab`, press
+  `Backspace`, type replacement text, then `Revert all`.
+- Select adjacent items at a text boundary, outdent from a nested list with
+  `Shift+Tab`, press `Backspace`, type replacement text, then `Revert all`.
+- Delete a boundary-spanning selection from the start of `Item 4` back toward
+  `Item 2`, type replacement text, then `Revert all`.
+- Indent a boundary selection, then create a new boundary selection from a
+  following item across the moved items, press `Backspace`, type replacement
+  text, then `Revert all`.
+- Indent `Item 3` under `Item 2`, then indent `Item 2` under `Item 1`, then
+  `Revert all`.
+- Create a deeper dependency chain by indenting `Item 3` under `Item 2`,
+  indenting `Item 4` under `Item 3`, then indenting `Item 2` under `Item 1`,
+  then `Revert all`.
+- Select `Item 2` and `Item 3` at a boundary, wrap with `ControlOrMeta+U`, press
+  `Backspace`, type replacement text, then `Revert all`.
+- Select `Item 1` and `Item 2` at a boundary, wrap with `ControlOrMeta+U`, press
+  `Backspace`, type replacement text, then `Revert all`.
+- A keyboard-navigated top-level list `Enter` case round-tripped during
+  exploration, but the reduced exact-cursor case
+  `Item| 3 -> Shift+ArrowUp -> Enter -> Revert all` is the failing repro and
+  should not be treated as a successful case.
+
+## Provisional List Items
+
+Initial document:
+
+```text
+1. Item One
+2. Item Two
+```
+
+- Press `Enter`, type `Draft A`, press `Enter`, type `Draft B`, select upward
+  from the start of `Draft B` into `Draft A`, press `Backspace`, type
+  replacement text, then `Revert all`.
+- Press `Enter`, type `Draft A`, press `Enter`, type `Draft B`, select downward
+  from `Draft A` into `Draft B`, press `Delete`, type replacement text, then
+  `Revert all`.
+
+## Nested Ordered List
+
+Initial document:
+
+```text
+1. Item 1
+2. Item 2
+   1. Item 2.1
+   2. Item 2.2
+   3. Item 2.3
+3. Item 3
+```
+
+- Select adjacent nested items at a text boundary, outdent with `Shift+Tab`,
+  press `Backspace`, type replacement text, then `Revert all`.
+- Select adjacent nested items at a text boundary, press `Enter`, type
+  replacement text, then `Revert all`.
+
+## Paragraphs And Blockquotes
+
+Initial document:
+
+```text
+Paragraph One
+
+Paragraph Two
+
+Paragraph Three
+```
+
+- Select across paragraph starts with `Shift+ArrowUp`, wrap with
+  `ControlOrMeta+U`, select a following boundary with `Shift+ArrowDown`, press
+  `Backspace`, type replacement text, then `Revert all`.
+- Select across paragraph starts with `Shift+ArrowUp`, wrap with
+  `ControlOrMeta+U`, press `Delete`, type replacement text, then `Revert all`.
+
+## No-Op Case
+
+This was not a successful round-trip scenario; it made no document change:
+
+- Select a boundary range that includes the first list item, then press `Tab`.
+  The command is a valid no-op because the first list item cannot be indented
+  under a previous sibling.

--- a/src/features/wrapUnwrap/__tests__/buildMaterializedPaths.test.ts
+++ b/src/features/wrapUnwrap/__tests__/buildMaterializedPaths.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import { createSchema } from "../../../testing/e2eTestSchema.js";
+import { buildMaterializedPaths } from "../buildMaterializedPaths.js";
+import { DOC_NODE_ID } from "../constants.js";
+
+const schema = createSchema();
+
+function getListDocJSON(includeHardBreak = false): object {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "bulletList",
+        attrs: { id: "list-1" },
+        content: [
+          {
+            type: "listItem",
+            attrs: { id: "item-1" },
+            content: [
+              {
+                type: "paragraph",
+                attrs: { id: "paragraph-1" },
+                content: [{ type: "text", text: "one" }],
+              },
+            ],
+          },
+          {
+            type: "listItem",
+            attrs: { id: "item-2" },
+            content: [
+              {
+                type: "paragraph",
+                attrs: { id: "paragraph-2" },
+                content: includeHardBreak
+                  ? [
+                      { type: "text", text: "two" },
+                      { type: "hardBreak", attrs: { id: "hard-break-1" } },
+                    ]
+                  : [{ type: "text", text: "two" }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("buildMaterializedPaths", () => {
+  it("builds materialized paths", () => {
+    const paths = buildMaterializedPaths(schema.nodeFromJSON(getListDocJSON()));
+
+    expect(Object.fromEntries(paths.entries())).toMatchObject({
+      "list-1": {
+        nodeType: "bulletList",
+        chain: [
+          {
+            nodeId: DOC_NODE_ID,
+            nodeType: DOC_NODE_ID,
+            nodeAttrs: {},
+            nodeMarks: [],
+            childSiblingIds: [null, null],
+            childIndex: 0,
+          },
+        ],
+      },
+      "item-1": {
+        nodeType: "listItem",
+        chain: [
+          {
+            nodeId: "list-1",
+            nodeType: "bulletList",
+            nodeAttrs: { id: "list-1" },
+            nodeMarks: [],
+            childSiblingIds: [null, "item-2"],
+            childIndex: 0,
+          },
+          {
+            nodeId: DOC_NODE_ID,
+            nodeType: DOC_NODE_ID,
+            nodeAttrs: {},
+            nodeMarks: [],
+            childSiblingIds: [null, null],
+            childIndex: 0,
+          },
+        ],
+      },
+      "paragraph-1": {
+        nodeType: "paragraph",
+        chain: [
+          {
+            nodeId: "item-1",
+            nodeType: "listItem",
+            nodeAttrs: { id: "item-1" },
+            nodeMarks: [],
+            childSiblingIds: [null, null],
+            childIndex: 0,
+          },
+          {
+            nodeId: "list-1",
+            nodeType: "bulletList",
+            nodeAttrs: { id: "list-1" },
+            nodeMarks: [],
+            childSiblingIds: [null, "item-2"],
+            childIndex: 0,
+          },
+          {
+            nodeId: DOC_NODE_ID,
+            nodeType: DOC_NODE_ID,
+            nodeAttrs: {},
+            nodeMarks: [],
+            childSiblingIds: [null, null],
+            childIndex: 0,
+          },
+        ],
+      },
+      "item-2": {
+        nodeType: "listItem",
+        chain: [
+          {
+            nodeId: "list-1",
+            nodeType: "bulletList",
+            nodeAttrs: { id: "list-1" },
+            nodeMarks: [],
+            childSiblingIds: ["item-1", null],
+            childIndex: 1,
+          },
+          {
+            nodeId: DOC_NODE_ID,
+            nodeType: DOC_NODE_ID,
+            nodeAttrs: {},
+            nodeMarks: [],
+            childSiblingIds: [null, null],
+            childIndex: 0,
+          },
+        ],
+      },
+      "paragraph-2": {
+        nodeType: "paragraph",
+        chain: [
+          {
+            nodeId: "item-2",
+            nodeType: "listItem",
+            nodeAttrs: { id: "item-2" },
+            nodeMarks: [],
+            childSiblingIds: [null, null],
+            childIndex: 0,
+          },
+          {
+            nodeId: "list-1",
+            nodeType: "bulletList",
+            nodeAttrs: { id: "list-1" },
+            nodeMarks: [],
+            childSiblingIds: ["item-1", null],
+            childIndex: 1,
+          },
+          {
+            nodeId: DOC_NODE_ID,
+            nodeType: DOC_NODE_ID,
+            nodeAttrs: {},
+            nodeMarks: [],
+            childSiblingIds: [null, null],
+            childIndex: 0,
+          },
+        ],
+      },
+    });
+  });
+
+  it("skips inline nodes", () => {
+    const paths = buildMaterializedPaths(
+      schema.nodeFromJSON(getListDocJSON(true)),
+    );
+
+    expect(paths.has("hard-break-1")).toBe(false);
+    expect([...paths.keys()]).toEqual([
+      "list-1",
+      "item-1",
+      "paragraph-1",
+      "item-2",
+      "paragraph-2",
+    ]);
+  });
+});

--- a/src/features/wrapUnwrap/__tests__/listStructure.playwright.test.ts
+++ b/src/features/wrapUnwrap/__tests__/listStructure.playwright.test.ts
@@ -1,0 +1,1567 @@
+import { test, expect } from "../../../__tests__/playwrightBaseTest.js";
+import { setupDocFromJSON } from "../../../__tests__/playwrightHelpers.js";
+import { EditorPage } from "../../../__tests__/playwrightPage.js";
+import { eq } from "prosemirror-test-builder";
+import {
+  guardStructureAddMarkAttrs,
+  guardStructureMarkObject,
+  guardStructureMoveMarkAttrs,
+} from "../types.js";
+
+test.describe("Structure changes in lists", () => {
+  test("Revert a single outdent (last item)", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item One" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Two" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Three" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Four" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Five" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // press shift+tab to outdent Item Five
+    await page.keyboard.press("Shift+Tab");
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Revert a single indent (middle item)", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 3" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // move to Item 2
+    await page.keyboard.press("ArrowUp");
+
+    // press tab to indent Item 2
+    await page.keyboard.press("Tab");
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Revert a single outdent (middle item)", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item One" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Two" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Three" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Four" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Five" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // go up to Item Three
+    for (let i = 0; i < 2; i++) {
+      await page.keyboard.press("ArrowUp");
+    }
+
+    // press shift+tab to outdent Item Three
+    await page.keyboard.press("Shift+Tab");
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Revert a multi outdent (two middle items)", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 3" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 4" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 5" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // go up to Item 3
+    for (let i = 0; i < 2; i++) {
+      await page.keyboard.press("ArrowUp");
+    }
+
+    // move to Item| 3
+    // eslint-disable-next-line @typescript-eslint/prefer-for-of
+    for (let i = 0; i < " 3".length; i++) {
+      await page.keyboard.press("ArrowLeft");
+    }
+
+    // select Item 3 and Item 2
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("ArrowUp");
+    await page.keyboard.up("Shift");
+
+    // press shift+tab to outdent Item 3 and Item 2
+    await page.keyboard.press("Shift+Tab");
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Revert a single outdent from a nested list (middle item)", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2" }],
+                },
+                {
+                  type: "orderedList",
+                  content: [
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.1" }],
+                        },
+                      ],
+                    },
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.2" }],
+                        },
+                      ],
+                    },
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.3" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 3" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // go up to Item 2.2
+    for (let i = 0; i < 2; i++) {
+      await page.keyboard.press("ArrowUp");
+    }
+
+    // press shift+tab to outdent Item 2.2
+    await page.keyboard.press("Shift+Tab");
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Revert a single outdent (top item)", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item One" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Two" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Three" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Four" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Five" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // go up to Item 1
+    for (let i = 0; i < 4; i++) {
+      await page.keyboard.press("ArrowUp");
+    }
+
+    // press shift+tab to outdent Item 1
+    await page.keyboard.press("Shift+Tab");
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Revert a multi indent (three middle items)", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2.1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2.2" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2.3" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 3" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 4" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 5" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // go up to Item 2.3
+    for (let i = 0; i < 3; i++) {
+      await page.keyboard.press("ArrowUp");
+    }
+
+    // move to Item| 2.3
+    // eslint-disable-next-line @typescript-eslint/prefer-for-of
+    for (let i = 0; i < " 2.3".length; i++) {
+      await page.keyboard.press("ArrowLeft");
+    }
+
+    // select Item 2.3, Item 2.2, Item 2.1
+    await page.keyboard.down("Shift");
+    for (let i = 0; i < 2; i++) {
+      await page.keyboard.press("ArrowUp");
+    }
+    await page.keyboard.up("Shift");
+
+    // press tab to indent Item 2.1, Item 2.2, Item 2.3
+    await page.keyboard.press("Tab");
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Revert multiple single outdents from a top level list into the root document (two items)", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        // top level list: Item 1, Item 2, Item 3, Item 4, Item 5
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2" }],
+                },
+                // nested list under Item 2: Item 2.1, Item 2.3, Item 2.4
+                {
+                  type: "orderedList",
+                  content: [
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.1" }],
+                        },
+                        // nested list under Item 2.1: Item 2.2
+                        {
+                          type: "orderedList",
+                          content: [
+                            {
+                              type: "listItem",
+                              content: [
+                                {
+                                  type: "paragraph",
+                                  content: [{ type: "text", text: "Item 2.2" }],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.3" }],
+                        },
+                      ],
+                    },
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.4" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 3" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 4" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 5" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // go up to Item 2
+    for (let i = 0; i < 7; i++) {
+      await page.keyboard.press("ArrowUp");
+    }
+
+    // press shift+tab to outdent Item 2
+    await page.keyboard.press("Shift+Tab");
+
+    // go down to Item 3
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press("ArrowDown");
+    }
+
+    // press shift+tab to outdent Item 3
+    await page.keyboard.press("Shift+Tab");
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Revert multiple single outdents from a nested list into the top level list (two items from the same nested list)", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        // top level list: Item 1, Item 2, Item 3, Item 4, Item 5
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2" }],
+                },
+                // nested list under Item 2: Item 2.1, Item 2.2, Item 2.3, Item 2.4
+                {
+                  type: "orderedList",
+                  content: [
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.1" }],
+                        },
+                      ],
+                    },
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.2" }],
+                        },
+                      ],
+                    },
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.3" }],
+                        },
+                      ],
+                    },
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.4" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 3" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 4" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 5" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // go up to Item 2.2
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press("ArrowUp");
+    }
+
+    // press shift+tab to outdent Item 2.2
+    await page.keyboard.press("Shift+Tab");
+
+    // go down to Item 2.3
+    await page.keyboard.press("ArrowDown");
+
+    // press shift+tab to outdent Item 2.3
+    await page.keyboard.press("Shift+Tab");
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Revert multiple single outdents from a nested list into the top level list (two items from different nested lists)", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        // top level list: Item 1, Item 2, Item 3, Item 4, Item 5
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2" }],
+                },
+                // nested list under Item 2: Item 2.1, Item 2.3, Item 2.4
+                {
+                  type: "orderedList",
+                  content: [
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.1" }],
+                        },
+                        // nested list under Item 2.1: Item 2.2
+                        {
+                          type: "orderedList",
+                          content: [
+                            {
+                              type: "listItem",
+                              content: [
+                                {
+                                  type: "paragraph",
+                                  content: [{ type: "text", text: "Item 2.2" }],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.3" }],
+                        },
+                      ],
+                    },
+                    {
+                      type: "listItem",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [{ type: "text", text: "Item 2.4" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 3" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 4" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 5" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // go up to Item 2.2
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press("ArrowUp");
+    }
+
+    // press shift+tab to outdent Item 2.2
+    await page.keyboard.press("Shift+Tab");
+
+    // go up to Item 2.1
+    await page.keyboard.press("ArrowUp");
+
+    // press shift+tab to outdent Item 2.1
+    await page.keyboard.press("Shift+Tab");
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Create a bullet list with an input rule after a paragraph split, and revert", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Item One" }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Item Two" }],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    expect(await editorPage.editor.locator("ul").count()).toBe(0);
+
+    // press Enter to create a new Paragraph
+    await page.keyboard.press("Enter");
+
+    // create a new bullet list
+    await page.keyboard.type("- ");
+
+    expect(await editorPage.editor.locator("ul").count()).toBe(1);
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Create an ordered list with an input rule after a paragraph split, and revert", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Item One" }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Item Two" }],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    expect(await editorPage.editor.locator("ol").count()).toBe(0);
+
+    // press Enter to create a new Paragraph
+    await page.keyboard.press("Enter");
+
+    // create a new ordered list
+    await page.keyboard.type("1. ");
+
+    expect(await editorPage.editor.locator("ol").count()).toBe(1);
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Moving an add-marked list item does not add a move mark", async ({
+    page,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item One" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Two" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    // press Enter to create a new list item
+    await page.keyboard.press("Enter");
+
+    // press shift+tab to outdent the new item
+    await page.keyboard.press("Shift+Tab");
+
+    const structureMarks = (
+      await page.evaluate(() => window.pmEditor.getProseMirrorMarksJSON())
+    ).filter(guardStructureMarkObject);
+
+    expect(structureMarks).toHaveLength(1);
+    expect(
+      structureMarks[0] && guardStructureAddMarkAttrs(structureMarks[0].attrs),
+    ).toBe(true);
+  });
+
+  test("Provisional list add can be split, moved, joined away, and reverted without creating extra move/join suggestions", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item One" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Two" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // Split Item Two to create a new provisional list item after it.
+    await page.keyboard.press("Enter");
+
+    let structureMarks = (await editorPage.getProseMirrorMarksJSON()).filter(
+      guardStructureMarkObject,
+    );
+    expect(structureMarks).toHaveLength(1);
+    expect(
+      structureMarks.every((mark) => guardStructureAddMarkAttrs(mark.attrs)),
+    ).toBe(true);
+
+    await page.keyboard.type("Draft A");
+    // Split Draft A to create a second provisional list item.
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Draft B");
+
+    structureMarks = (await editorPage.getProseMirrorMarksJSON()).filter(
+      guardStructureMarkObject,
+    );
+    expect(structureMarks).toHaveLength(2);
+    expect(
+      structureMarks.every((mark) => guardStructureAddMarkAttrs(mark.attrs)),
+    ).toBe(true);
+
+    // Indent Draft B so it becomes nested under Draft A.
+    await page.keyboard.press("Tab");
+
+    structureMarks = (await editorPage.getProseMirrorMarksJSON()).filter(
+      guardStructureMarkObject,
+    );
+    expect(structureMarks).toHaveLength(2);
+    expect(
+      structureMarks.every((mark) => guardStructureAddMarkAttrs(mark.attrs)),
+    ).toBe(true);
+
+    await page.evaluate(() => {
+      let draftBPos: number | undefined;
+      window.pmEditor.view.state.doc.descendants((node, pos) => {
+        if (draftBPos === undefined && node.isTextblock) {
+          const text = node.textContent;
+          if (text === "Draft B") {
+            draftBPos = pos + 1;
+            return false;
+          }
+        }
+        return true;
+      });
+
+      if (draftBPos === undefined) {
+        throw new Error("Could not find Draft B textblock");
+      }
+
+      window.pmEditor.setCursorToPosition(draftBPos);
+      window.pmEditor.view.focus();
+    });
+
+    // Lift Draft B back out of the nested list, without creating a block join suggestion.
+    await page.keyboard.press("Backspace");
+
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+    structureMarks = (await editorPage.getProseMirrorMarksJSON()).filter(
+      guardStructureMarkObject,
+    );
+    expect(structureMarks).toHaveLength(2);
+    expect(
+      structureMarks.every((mark) => guardStructureAddMarkAttrs(mark.attrs)),
+    ).toBe(true);
+
+    // Join Draft B into Draft A, still without creating a block join suggestion.
+    await page.keyboard.press("Backspace");
+
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+    structureMarks = (await editorPage.getProseMirrorMarksJSON()).filter(
+      guardStructureMarkObject,
+    );
+    expect(
+      structureMarks.every((mark) => guardStructureAddMarkAttrs(mark.attrs)),
+    ).toBe(true);
+
+    await editorPage.revertAll();
+
+    const docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Moving an accepted add-marked list item creates a move mark", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item One" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Two" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    // press Enter to create a new list item
+    await page.keyboard.press("Enter");
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    await editorPage.applyAll();
+
+    // press shift+tab to outdent the accepted item
+    await page.keyboard.press("Shift+Tab");
+
+    const structureMarks = (
+      await page.evaluate(() => window.pmEditor.getProseMirrorMarksJSON())
+    ).filter(guardStructureMarkObject);
+
+    expect(structureMarks).toHaveLength(1);
+    expect(
+      structureMarks[0] && guardStructureMoveMarkAttrs(structureMarks[0].attrs),
+    ).toBe(true);
+  });
+
+  test("Revert a moved add-marked list item", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item One" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Two" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // press Enter to create a new list item
+    await page.keyboard.press("Enter");
+
+    // press shift+tab to outdent the new item
+    await page.keyboard.press("Shift+Tab");
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Create a list using an input rule, indent a middle item to create a nested list, and revert", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Item One" }],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    expect(await editorPage.editor.locator("ul").count()).toBe(0);
+
+    // press Enter to create a new Paragraph
+    await page.keyboard.press("Enter");
+
+    // create a new list
+    await page.keyboard.type("- ");
+
+    expect(await editorPage.editor.locator("ul").count()).toBe(1);
+    expect(await editorPage.editor.locator("li").count()).toBe(1);
+
+    // fill Item 1
+    await page.keyboard.type("Item 1");
+
+    // create Item 2
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Item 2");
+
+    // create Item 3
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Item 3");
+
+    expect(await editorPage.editor.locator("ul").count()).toBe(1);
+    expect(await editorPage.editor.locator("li").count()).toBe(3);
+
+    // indent Item 2
+    await page.keyboard.press("ArrowUp");
+    await page.keyboard.press("Tab");
+
+    expect(await editorPage.editor.locator("ul").count()).toBe(2);
+    expect(await editorPage.editor.locator("li").count()).toBe(3);
+
+    let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
+
+    await editorPage.revertAll();
+
+    docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Indenting then outdenting a list item cancels inverse move marks", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 1" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 2" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item 3" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // move to Item 2
+    await page.keyboard.press("ArrowUp");
+
+    // press tab to indent Item 2
+    await page.keyboard.press("Tab");
+
+    let structureMarks = (
+      await page.evaluate(() => window.pmEditor.getProseMirrorMarksJSON())
+    ).filter(guardStructureMarkObject);
+
+    expect(structureMarks).toHaveLength(1);
+    expect(
+      structureMarks[0] && guardStructureMoveMarkAttrs(structureMarks[0].attrs),
+    ).toBe(true);
+
+    // press shift+tab to outdent Item 2 back to its original location
+    await page.keyboard.press("Shift+Tab");
+
+    structureMarks = (
+      await page.evaluate(() => window.pmEditor.getProseMirrorMarksJSON())
+    ).filter(guardStructureMarkObject);
+
+    expect(structureMarks).toHaveLength(0);
+
+    const docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+});

--- a/src/features/wrapUnwrap/__tests__/listStructure.playwright.test.ts
+++ b/src/features/wrapUnwrap/__tests__/listStructure.playwright.test.ts
@@ -227,6 +227,21 @@ test.describe("Structure changes in lists", () => {
     // press shift+tab to outdent Item Three
     await page.keyboard.press("Shift+Tab");
 
+    const structureMarks = (await editorPage.getProseMirrorMarksJSON()).filter(
+      guardStructureMarkObject,
+    );
+    expect(structureMarks).toHaveLength(3);
+
+    const primaryMarks = structureMarks.filter(
+      (mark) => mark.attrs.data.role !== "supporting",
+    );
+    const supportingMarks = structureMarks.filter(
+      (mark) => mark.attrs.data.role === "supporting",
+    );
+
+    expect(primaryMarks).toHaveLength(1);
+    expect(supportingMarks).toHaveLength(2);
+
     let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
     expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
 

--- a/src/features/wrapUnwrap/__tests__/listStructure.playwright.test.ts
+++ b/src/features/wrapUnwrap/__tests__/listStructure.playwright.test.ts
@@ -138,10 +138,10 @@ test.describe("Structure changes in lists", () => {
     const docJSON = await editorPage.getDocJSON();
 
     // move to Item 2
-    await page.keyboard.press("ArrowUp");
+    await editorPage.pressKey("ArrowUp", { waitForSelectionChange: true });
 
     // press tab to indent Item 2
-    await page.keyboard.press("Tab");
+    await editorPage.pressKey("Tab");
 
     let docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
     expect(eq(docs.currentDoc, docs.expectedDoc)).not.toBeTruthy();
@@ -220,12 +220,12 @@ test.describe("Structure changes in lists", () => {
     const docJSON = await editorPage.getDocJSON();
 
     // go up to Item Three
-    for (let i = 0; i < 2; i++) {
-      await page.keyboard.press("ArrowUp");
-    }
+    await editorPage.pressKeyMultiple("ArrowUp", 2, {
+      waitForSelectionChange: true,
+    });
 
     // press shift+tab to outdent Item Three
-    await page.keyboard.press("Shift+Tab");
+    await editorPage.pressKey("Shift+Tab");
 
     const structureMarks = (await editorPage.getProseMirrorMarksJSON()).filter(
       guardStructureMarkObject,

--- a/src/features/wrapUnwrap/__tests__/listStructureTextEdits.playwright.test.ts
+++ b/src/features/wrapUnwrap/__tests__/listStructureTextEdits.playwright.test.ts
@@ -1,0 +1,172 @@
+import { test, expect } from "../../../__tests__/playwrightBaseTest.js";
+import { setupDocFromJSON } from "../../../__tests__/playwrightHelpers.js";
+import { EditorPage } from "../../../__tests__/playwrightPage.js";
+import { eq } from "prosemirror-test-builder";
+import {
+  guardStructureMarkObject,
+  guardStructureMoveMarkAttrs,
+} from "../types.js";
+
+test.describe("Structure changes with text edits in lists", () => {
+  test("Revert all reverts a moved list item and text edits inside it", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item One" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Two" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Three" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+    const docJSON = await editorPage.getDocJSON();
+
+    // move to Item Two
+    await page.keyboard.press("ArrowUp");
+
+    // indent Item Two under Item One
+    await page.keyboard.press("Tab");
+
+    // delete "Two"
+    // eslint-disable-next-line @typescript-eslint/prefer-for-of
+    for (let i = 0; i < "Two".length; i++) {
+      await page.keyboard.press("Backspace");
+    }
+
+    // insert "Second"
+    await page.keyboard.type("Second");
+
+    expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(1);
+    expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(1);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+    await editorPage.revertAll();
+
+    const docs = await editorPage.getCurrentAndExpectedDoc(docJSON);
+    expect(eq(docs.currentDoc, docs.expectedDoc)).toBeTruthy();
+  });
+
+  test("Revert a structure mark preserves text edits inside the moved list item", async ({
+    page,
+    deletionMarksVisibility,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item One" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Two" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Item Three" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page, deletionMarksVisibility);
+
+    // move to Item Two
+    await page.keyboard.press("ArrowUp");
+
+    // indent Item Two under Item One
+    await page.keyboard.press("Tab");
+
+    // delete "Two"
+    // eslint-disable-next-line @typescript-eslint/prefer-for-of
+    for (let i = 0; i < "Two".length; i++) {
+      await page.keyboard.press("Backspace");
+    }
+
+    // insert "Second"
+    await page.keyboard.type("Second");
+
+    const structureMarks = (await editorPage.getProseMirrorMarksJSON()).filter(
+      guardStructureMarkObject,
+    );
+    expect(structureMarks).toHaveLength(1);
+    expect(
+      structureMarks[0] && guardStructureMoveMarkAttrs(structureMarks[0].attrs),
+    ).toBe(true);
+    expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(1);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+    await editorPage.revertSuggestion(structureMarks[0]?.attrs.id as number);
+
+    expect(await editorPage.getProseMirrorMarkCount("structure")).toBe(0);
+    expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(1);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+    const currentDoc = await editorPage.getCurrentDoc();
+    const list = currentDoc.child(0);
+    expect(list.type.name).toBe("orderedList");
+    expect(list.childCount).toBe(3);
+    expect(list.child(0).childCount).toBe(1);
+    expect(list.child(1).childCount).toBe(1);
+    expect(list.child(2).childCount).toBe(1);
+  });
+});

--- a/src/features/wrapUnwrap/__tests__/splitDetection.test.ts
+++ b/src/features/wrapUnwrap/__tests__/splitDetection.test.ts
@@ -93,7 +93,10 @@ describe("structural context direct child matching", () => {
     );
 
     expect(addedParagraph.attrs["id"]).toBe("paragraph-2");
-    expect(structureMark?.attrs["data"]).toEqual({ op: { op: "add" } });
+    expect(structureMark?.attrs["data"]).toEqual({
+      op: { op: "add" },
+      role: "primary",
+    });
   });
 
   it("ignores a new hard break nested inside a paragraph under a list item", () => {

--- a/src/features/wrapUnwrap/__tests__/splitDetection.test.ts
+++ b/src/features/wrapUnwrap/__tests__/splitDetection.test.ts
@@ -1,0 +1,560 @@
+import { describe, expect, it } from "vitest";
+import { type Node } from "prosemirror-model";
+
+import { createSchema } from "../../../testing/e2eTestSchema.js";
+import { suggestStructureChanges } from "../structureChangesPlugin.js";
+import { type StructuralContextPath } from "../types.js";
+
+const schema = createSchema();
+const listStructures = [
+  ["orderedList", "listItem"],
+  ["bulletList", "listItem"],
+] satisfies StructuralContextPath[];
+
+function structureMarkCount(doc: Node) {
+  let count = 0;
+  doc.descendants((node) => {
+    count += node.marks.filter((mark) => mark.type.name === "structure").length;
+  });
+  return count;
+}
+
+function structureAddMarkJSON(id = 1) {
+  return {
+    type: "structure",
+    attrs: {
+      id,
+      data: { op: { op: "add" } },
+    },
+  };
+}
+
+describe("structural context direct child matching", () => {
+  it("keeps a new paragraph directly under a list item as a Structure add", () => {
+    const before = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  content: [{ type: "text", text: "one" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const after = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  content: [{ type: "text", text: "one" }],
+                },
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-2" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = suggestStructureChanges(before, after, listStructures);
+
+    expect(result.handled).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(structureMarkCount(result.transform.doc)).toBe(1);
+
+    const addedParagraph = result.transform.doc.child(0).child(0).child(1);
+    const structureMark = addedParagraph.marks.find(
+      (mark) => mark.type.name === "structure",
+    );
+
+    expect(addedParagraph.attrs["id"]).toBe("paragraph-2");
+    expect(structureMark?.attrs["data"]).toEqual({ op: { op: "add" } });
+  });
+
+  it("ignores a new hard break nested inside a paragraph under a list item", () => {
+    const before = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  content: [{ type: "text", text: "one" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const after = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  content: [
+                    { type: "text", text: "one" },
+                    { type: "hardBreak", attrs: { id: "hard-break-1" } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = suggestStructureChanges(before, after, listStructures);
+
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBeUndefined();
+    expect(structureMarkCount(result.transform.doc)).toBe(0);
+  });
+});
+
+describe("detect splits to hand off to the main plugin", () => {
+  it("falls through when a new paragraph is split-derived inside an existing list item", () => {
+    const before = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  content: [{ type: "text", text: "HelloWorld" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const after = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  content: [{ type: "text", text: "Hello" }],
+                },
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-2" },
+                  content: [{ type: "text", text: "World" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = suggestStructureChanges(before, after, listStructures);
+
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBe("split-derived-add");
+    expect(structureMarkCount(result.transform.doc)).toBe(0);
+  });
+
+  it("falls through when a new list item is split-derived from its previous sibling", () => {
+    const before = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  content: [{ type: "text", text: "test item" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const after = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  content: [{ type: "text", text: "test " }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              attrs: { id: "item-2" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-2" },
+                  content: [{ type: "text", text: "item" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = suggestStructureChanges(before, after, listStructures);
+
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBe("split-derived-add");
+    expect(structureMarkCount(result.transform.doc)).toBe(0);
+  });
+
+  it("keeps an empty new node as a Structure add suggestion", () => {
+    const before = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  content: [{ type: "text", text: "test item" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const after = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  content: [{ type: "text", text: "test item" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              attrs: { id: "item-2" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-2" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = suggestStructureChanges(before, after, listStructures);
+
+    expect(result.handled).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(structureMarkCount(result.transform.doc)).toBe(1);
+  });
+
+  it("does not match split-derived text from a non-adjacent previous sibling", () => {
+    const before = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  content: [{ type: "text", text: "abc" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              attrs: { id: "item-2" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-2" },
+                  content: [{ type: "text", text: "middle" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const after = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  content: [{ type: "text", text: "a" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              attrs: { id: "item-2" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-2" },
+                  content: [{ type: "text", text: "middle" }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              attrs: { id: "item-3" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-3" },
+                  content: [{ type: "text", text: "bc" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = suggestStructureChanges(before, after, listStructures);
+
+    expect(result.handled).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(structureMarkCount(result.transform.doc)).toBe(1);
+  });
+
+  it("keeps a new paragraph as a Structure add when previous sibling was a Structure add", () => {
+    const before = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  marks: [structureAddMarkJSON()],
+                  content: [{ type: "text", text: "HelloWorld" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const after = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  marks: [structureAddMarkJSON()],
+                  content: [{ type: "text", text: "Hello" }],
+                },
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-2" },
+                  content: [{ type: "text", text: "World" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = suggestStructureChanges(before, after, listStructures);
+
+    expect(result.handled).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(structureMarkCount(result.transform.doc)).toBe(2);
+  });
+
+  it("keeps a new list item as a Structure add when previous sibling was a Structure add", () => {
+    const before = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  marks: [structureAddMarkJSON()],
+                  content: [{ type: "text", text: "test item" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const after = schema.nodeFromJSON({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          attrs: { id: "list-1" },
+          content: [
+            {
+              type: "listItem",
+              attrs: { id: "item-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-1" },
+                  marks: [structureAddMarkJSON()],
+                  content: [{ type: "text", text: "test " }],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              attrs: { id: "item-2" },
+              content: [
+                {
+                  type: "paragraph",
+                  attrs: { id: "paragraph-2" },
+                  content: [{ type: "text", text: "item" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = suggestStructureChanges(before, after, listStructures);
+
+    expect(result.handled).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(structureMarkCount(result.transform.doc)).toBe(2);
+  });
+});

--- a/src/features/wrapUnwrap/addIdAttr.ts
+++ b/src/features/wrapUnwrap/addIdAttr.ts
@@ -1,0 +1,65 @@
+import { type DOMOutputSpec, type NodeSpec } from "prosemirror-model";
+
+export const addIdAttr = (nodeSpec: NodeSpec): NodeSpec => {
+  const { toDOM, parseDOM } = nodeSpec;
+  if (!toDOM || !parseDOM) {
+    return nodeSpec;
+  }
+
+  const newNodeSpec: NodeSpec = {
+    ...nodeSpec,
+    attrs: {
+      ...(nodeSpec.attrs ?? {}),
+      id: { default: null },
+    },
+    toDOM(node) {
+      const domOutputSpec = toDOM(node);
+      if (!Array.isArray(domOutputSpec)) {
+        console.warn(
+          "addIdAttr",
+          "domOutputSpec is not an array, id is not added",
+          domOutputSpec,
+        );
+        return domOutputSpec;
+      }
+
+      const id = typeof node.attrs["id"] === "string" ? node.attrs["id"] : null;
+      const attrs = domOutputSpec[1] as unknown;
+
+      if (
+        !Array.isArray(attrs) &&
+        typeof attrs === "object" &&
+        attrs !== null
+      ) {
+        const theRest = (domOutputSpec as unknown as []).slice(2);
+        const result = [
+          domOutputSpec[0],
+          id ? { ...attrs, "data-id": id } : attrs,
+          ...theRest,
+        ];
+        return result as unknown as DOMOutputSpec;
+      }
+
+      const theRest = (domOutputSpec as unknown as []).slice(1);
+      const result = [
+        domOutputSpec[0],
+        id ? { "data-id": id } : {},
+        ...theRest,
+      ];
+      return result as unknown as DOMOutputSpec;
+    },
+    parseDOM: [
+      ...parseDOM.map((tagParseRule) => ({
+        ...tagParseRule,
+        getAttrs(dom: HTMLElement) {
+          const id = dom.getAttribute("data-id");
+          return tagParseRule.getAttrs
+            ? { ...tagParseRule.getAttrs(dom), id }
+            : { id };
+        },
+      })),
+    ],
+  };
+
+  return newNodeSpec;
+};

--- a/src/features/wrapUnwrap/apply/applyStructureSuggestions.ts
+++ b/src/features/wrapUnwrap/apply/applyStructureSuggestions.ts
@@ -1,0 +1,68 @@
+import { type Node } from "prosemirror-model";
+import { getSuggestionMarks } from "../../../utils.js";
+import { type Mark } from "prosemirror-model";
+import { type Transform } from "prosemirror-transform";
+import { type SuggestionId } from "../../../generateId.js";
+
+export function applyStructureSuggestionsInNode({
+  tr,
+  node,
+  suggestionId,
+  from,
+  to,
+}: {
+  tr: Transform;
+  node: Node;
+  suggestionId?: SuggestionId;
+  from?: number | undefined;
+  to?: number | undefined;
+}) {
+  const { structure } = getSuggestionMarks(node.type.schema);
+
+  const suggestionIds = new Set<SuggestionId>();
+
+  node.descendants((node, pos) => {
+    if (from !== undefined && pos < from) {
+      return true;
+    }
+    if (to !== undefined && pos > to) {
+      return false;
+    }
+    if (node.isText) return true;
+    if (!structure.isInSet(node.marks)) return true;
+
+    node.marks.forEach((mark) => {
+      if (mark.type !== structure) return;
+      const markSuggestionId = mark.attrs["id"] as SuggestionId;
+      if (suggestionId != null && markSuggestionId !== suggestionId) return;
+      suggestionIds.add(markSuggestionId);
+    });
+
+    return true;
+  });
+
+  for (const suggestionId of suggestionIds) {
+    applyOneStructureSuggestion(tr, suggestionId);
+  }
+}
+
+function applyOneStructureSuggestion(
+  tr: Transform,
+  suggestionId: SuggestionId,
+) {
+  const { structure } = getSuggestionMarks(tr.doc.type.schema);
+  tr.doc.descendants((node, pos) => {
+    if (node.isText) return true;
+    if (!structure.isInSet(node.marks)) return true;
+    node.marks.forEach((mark) => {
+      if (mark.type !== structure) return;
+      if (mark.attrs["id"] !== suggestionId) return;
+      applyStructureMark(tr, mark, pos);
+    });
+    return true;
+  });
+}
+
+function applyStructureMark(tr: Transform, mark: Mark, pos: number) {
+  tr.removeNodeMark(pos, mark);
+}

--- a/src/features/wrapUnwrap/apply/index.ts
+++ b/src/features/wrapUnwrap/apply/index.ts
@@ -1,0 +1,23 @@
+import { Transform } from "prosemirror-transform";
+import { type Node } from "prosemirror-model";
+import { applyStructureSuggestionsInNode } from "./applyStructureSuggestions.js";
+import { type SuggestionId } from "../../../generateId.js";
+
+export function applyAllStructureSuggestions(
+  node: Node,
+  from?: number,
+  to?: number,
+) {
+  const tr = new Transform(node);
+  applyStructureSuggestionsInNode({ tr, node: tr.doc, from, to });
+  return tr;
+}
+
+export function applyStructureSuggestion(
+  node: Node,
+  suggestionId: SuggestionId,
+) {
+  const tr = new Transform(node);
+  applyStructureSuggestionsInNode({ tr, node: tr.doc, suggestionId });
+  return tr;
+}

--- a/src/features/wrapUnwrap/areEquivalentStructureMarks.ts
+++ b/src/features/wrapUnwrap/areEquivalentStructureMarks.ts
@@ -1,0 +1,25 @@
+import { type Mark } from "prosemirror-model";
+import { sameParentChain } from "./sameParentChain.js";
+import { guardStructureMarkAttrs } from "./types.js";
+
+export function areEquivalentStructureMarks(a: Mark, b: Mark) {
+  if (a.type !== b.type) return false;
+  if (!guardStructureMarkAttrs(a.attrs)) return false;
+  if (!guardStructureMarkAttrs(b.attrs)) return false;
+
+  const aOp = a.attrs.data.op;
+  const bOp = b.attrs.data.op;
+  if (aOp.op !== bOp.op) return false;
+
+  if (aOp.op === "add" && bOp.op === "add") {
+    return a.attrs.id === b.attrs.id;
+  }
+
+  if (aOp.op === "move" && bOp.op === "move") {
+    return (
+      sameParentChain(aOp.from, bOp.from) && sameParentChain(aOp.to, bOp.to)
+    );
+  }
+
+  return false;
+}

--- a/src/features/wrapUnwrap/buildMaterializedPaths.ts
+++ b/src/features/wrapUnwrap/buildMaterializedPaths.ts
@@ -1,0 +1,100 @@
+import { getNodeId } from "./getNodeId.js";
+import {
+  type MaterializedPaths,
+  type DocParent,
+  type Parent,
+} from "./types.js";
+import { DOC_NODE_ID } from "./constants.js";
+import { type Node } from "prosemirror-model";
+
+const TRACE_ENABLED = false;
+function trace(...args: unknown[]) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!TRACE_ENABLED) return;
+  console.log("[structureChanges]", ...args);
+}
+
+export function buildMaterializedPaths(doc: Node): MaterializedPaths {
+  const perfPaths = performance.now();
+  const paths: MaterializedPaths = new Map();
+
+  // add direct doc children first since they have a specific parent signature due to doc not having an ID
+  doc.children.forEach((node, index, children) => {
+    const nodeId = getNodeId(node);
+    if (nodeId == null) return;
+
+    const leftSibling = children[index - 1];
+    const leftSiblingId = leftSibling ? getNodeId(leftSibling) : null;
+
+    const rightSibling = children[index + 1];
+    const rightSiblingId = rightSibling ? getNodeId(rightSibling) : null;
+
+    const parent: DocParent = {
+      nodeId: DOC_NODE_ID,
+      nodeType: DOC_NODE_ID,
+      nodeAttrs: {},
+      nodeMarks: [],
+      childSiblingIds: [leftSiblingId, rightSiblingId],
+      childIndex: index,
+    };
+
+    paths.set(nodeId, { nodeType: node.type.name, node, chain: [parent] });
+  });
+
+  // now add the rest of the nodes
+  doc.descendants((node, _pos, parent, childIndex) => {
+    if (node.isInline) return false;
+
+    const nodeId = getNodeId(node);
+    if (nodeId == null) return true;
+
+    // this is to avoid processing direct doc children twice
+    if (paths.has(nodeId)) return true;
+
+    if (parent == null) return true;
+
+    const parentId = getNodeId(parent);
+    if (parentId == null) return true;
+
+    // by definition, for any node it's parent chain should already exist
+    // because we go downwards
+    const parentChain = paths.get(parentId);
+    if (parentChain == null) return true;
+
+    const leftSibling = parent.children[childIndex - 1];
+    const leftSiblingId = leftSibling ? getNodeId(leftSibling) : null;
+
+    const rightSibling = parent.children[childIndex + 1];
+    const rightSiblingId = rightSibling ? getNodeId(rightSibling) : null;
+
+    // (this node parent chain) is (parent chain of the parent node) + (the parent node itself)
+
+    const parentDesc: Parent = {
+      nodeId: parentId,
+      nodeType: parent.type.name,
+      nodeAttrs: parent.attrs,
+      nodeMarks: parent.marks.map((mark) => mark.toJSON() as object),
+      childSiblingIds: [leftSiblingId, rightSiblingId],
+      childIndex: childIndex,
+    };
+
+    const chain: Parent[] = [parentDesc, ...parentChain.chain];
+    paths.set(nodeId, {
+      nodeType: node.type.name,
+      node,
+      chain,
+    });
+
+    return true;
+  });
+
+  trace(
+    "perf",
+    "buildMaterializedPaths",
+    "took",
+    Number((performance.now() - perfPaths).toFixed(2)),
+    "ms",
+  );
+
+  return paths;
+}

--- a/src/features/wrapUnwrap/buildMaterializedPaths.ts
+++ b/src/features/wrapUnwrap/buildMaterializedPaths.ts
@@ -67,8 +67,8 @@ export function buildMaterializedPaths(doc: Node): MaterializedPaths {
     const rightSibling = parent.children[childIndex + 1];
     const rightSiblingId = rightSibling ? getNodeId(rightSibling) : null;
 
-    // (this node parent chain) is (parent chain of the parent node) + (the parent node itself)
-
+    // Store sibling IDs with each parent because revert needs an insertion
+    // anchor that survives unrelated edits better than a raw child index.
     const parentDesc: Parent = {
       nodeId: parentId,
       nodeType: parent.type.name,

--- a/src/features/wrapUnwrap/constants.ts
+++ b/src/features/wrapUnwrap/constants.ts
@@ -1,0 +1,4 @@
+export const DOC_NODE_ID = "__doc__";
+export const STRUCTURE_CHANGES_ADD_MARKS = "structure-changes-add-mark-type";
+export const STRUCTURE_CHANGES_REVERT_MARKS =
+  "structure-changes-revert-mark-type";

--- a/src/features/wrapUnwrap/docs/adr/0001-structure-suggestion-revert-order.md
+++ b/src/features/wrapUnwrap/docs/adr/0001-structure-suggestion-revert-order.md
@@ -1,0 +1,15 @@
+# Structure Suggestion Revert Order
+
+Rejecting changes reverts Structure suggestions before inline suggestion
+cleanup, because structure revert changes document shape and inline cleanup must
+run against the remaining shape. Structure marks are reverted from the current
+document in right-to-left order, searching again after each revert, so nested
+Structure marks are handled after prior reverts have changed positions and local
+descendants are removed before ancestors.
+
+When a requested Structure suggestion depends on another stacked Structure move
+suggestion on the same content node, revert the prerequisite suggestion first
+because same-node stacked moves are the dependency case we understand today.
+This is good enough for current coverage, not the final dependency model; a full
+topological sort across the document is the likely future direction once
+cross-node dependencies are defined precisely.

--- a/src/features/wrapUnwrap/docs/adr/0002-provisional-adds-and-inverse-moves.md
+++ b/src/features/wrapUnwrap/docs/adr/0002-provisional-adds-and-inverse-moves.md
@@ -1,0 +1,22 @@
+# Provisional Adds And Inverse Moves
+
+A Structure add suggestion absorbs later Structure move suggestions while it is
+provisional, because moving provisional new structure is part of shaping the
+addition before review. An Inverse move on the same content node cancels the
+existing Structure mark instead of adding another mark, because the original
+move no longer represents pending review work.
+
+When a block join joins nodes and any joined node is still Structure-add-marked,
+the physical join still happens but no Block join suggestion marker is created.
+Joining away provisional added structure is cancellation of that pending add,
+not a separate Block join suggestion.
+
+When split-derived detection sees a candidate previous sibling whose subtree is
+still Structure-add-marked in the before-doc, it does not treat the new node as
+split-derived accepted content. Editing inside provisional new structure should
+produce provisional Structure add suggestions until that structure is accepted.
+
+This trades away full chronological edit history for clearer pending review work
+in those two cases. It is not a global simplification or a dependency graph
+across nodes: non-cancelling Structure move suggestions on the same node can
+still stack.

--- a/src/features/wrapUnwrap/docs/adr/0003-configurable-structural-context-paths.md
+++ b/src/features/wrapUnwrap/docs/adr/0003-configurable-structural-context-paths.md
@@ -1,0 +1,29 @@
+# Configurable Structural Context Paths
+
+Structure tracking uses consumer-provided Structural context paths made of
+concrete ProseMirror node type names, such as `["orderedList", "listItem"]` or
+`["blockquote"]`, instead of hardcoded list node names. The boolean
+`experimental_trackStructureChanges` remains the explicit feature gate, and a
+non-empty `experimental_trackStructures` config is required when that gate is
+enabled.
+
+Configured node names are not runtime-validated against the schema for now;
+consumers are responsible for passing names that exist in their schema. Every
+node type in a Structural context path is structural context only, never a
+Structure mark target. Structure marks are placed on stable content nodes whose
+immediate parent chain ends with the configured context path, descending through
+nested configured context nodes when needed.
+
+Structural context paths match as contiguous parent-child ancestor shapes, not
+as loose node-type membership. For example, `["orderedList", "listItem"]`
+matches content whose immediate parent chain ends with
+`orderedList -> listItem`. It does not mean "any chain containing `orderedList`
+or `listItem`." Single-node paths such as `["blockquote"]` match direct children
+of that node type, not arbitrary nested descendants. The flattened set of
+configured node types is still used only to decide which nodes are structural
+context nodes and therefore cannot receive Structure marks themselves.
+
+This preserves the existing Structure suggestion model while making the tracked
+structural contexts configurable. We are intentionally deferring semantic
+aliases such as `"list"`, runtime schema validation, and configurable mark
+targets until there is evidence that consumers need them.

--- a/src/features/wrapUnwrap/docs/adr/0004-split-derived-add-fallthrough.md
+++ b/src/features/wrapUnwrap/docs/adr/0004-split-derived-add-fallthrough.md
@@ -1,0 +1,8 @@
+# Split-Derived Adds Fall Through
+
+When structure detection sees a newly materialized content node whose raw text
+came from splitting an immediate accepted sibling, it returns
+`reason: "split-derived-add"` and leaves the whole transaction to normal
+suggestion tracking. This avoids mixing structure and text ownership inside one
+transaction, and keeps split-derived content out of **Structure add
+suggestions**.

--- a/src/features/wrapUnwrap/docs/adr/0004-split-derived-add-fallthrough.md
+++ b/src/features/wrapUnwrap/docs/adr/0004-split-derived-add-fallthrough.md
@@ -4,5 +4,5 @@ When structure detection sees a newly materialized content node whose raw text
 came from splitting an immediate accepted sibling, it returns
 `reason: "split-derived-add"` and leaves the whole transaction to normal
 suggestion tracking. This avoids mixing structure and text ownership inside one
-transaction, and keeps split-derived content out of **Structure add
-suggestions**.
+transaction, and keeps split-derived content out of the **Structure add
+suggestion** path.

--- a/src/features/wrapUnwrap/docs/adr/0005-primary-and-supporting-structure-marks.md
+++ b/src/features/wrapUnwrap/docs/adr/0005-primary-and-supporting-structure-marks.md
@@ -1,0 +1,12 @@
+# Primary And Supporting Structure Marks
+
+Structure suggestions keep every Structure mark needed to apply or revert a
+structural edit, but only Primary Structure marks represent the user-visible
+source of the suggestion.
+
+Supporting Structure marks remain in the same suggestion ID for collateral
+wrapper movement, because dropping them would weaken revert correctness while
+showing them as normal changes would expose implementation details to users. We
+chose explicit mark roles over presentation-only inference or storing supporting
+operations on the primary mark, because role metadata keeps apply/revert
+ID-based and makes the visibility contract local to each mark.

--- a/src/features/wrapUnwrap/docs/structure-changes-tracking.md
+++ b/src/features/wrapUnwrap/docs/structure-changes-tracking.md
@@ -85,7 +85,8 @@ not tracked yet.
      tracking owns the transaction.
    - if the after Parent chain is a direct child of a configured contiguous
      Structural context path, create an `add` op.
-7. Add Structure marks to the affected content nodes.
+7. Classify Structure marks as primary or supporting, then add them to the
+   affected content nodes.
 8. Applying removes Structure marks.
 9. Reverting uses stored Parent chains to delete added nodes or move existing
    nodes back.
@@ -97,6 +98,7 @@ The structure-tracking implementation is split across these stable areas:
 - transaction integration and structure diffing
 - materialized Parent chain construction and comparison
 - Structure mark attrs and operation guards
+- Structure mark role classification
 - unique-node-ID settling
 - Structure suggestion apply/revert commands
 - transaction shaping for compound editor transactions
@@ -117,6 +119,9 @@ The structure-tracking implementation is split across these stable areas:
   whose type appears in a configured Structural context path.
 - A Structure add suggestion is still provisional new structure. Moving it must
   not add Structure move suggestions until the add suggestion is accepted.
+- A Structure mark's role controls product visibility, not apply/revert
+  membership. Role-less marks are primary. Supporting marks must remain part of
+  suggestion-ID apply/revert.
 - Stored parent descriptors must remain sufficient to recreate missing ancestor
   wrappers and position the restored node near stable siblings.
 - Public apply/revert commands must set `suggestChangesKey` meta with
@@ -143,7 +148,7 @@ The structure-tracking implementation is split across these stable areas:
 6. All structure ops from that detection pass share one suggestion ID.
 7. A transform over the after-doc updates `structure` node marks on affected
    content nodes. It usually adds marks, but it can also remove an Inverse move.
-   The mark data stores the operation.
+   The mark data stores the operation and mark role.
 8. If structure detection handled the transaction, the normal text-suggestion
    transform is skipped for that transaction.
 9. Applying a Structure suggestion removes the Structure marks.
@@ -208,10 +213,15 @@ for future work and debugging, but index shifts alone are not treated as moves.
 `sameParentChain` compares only Parent chain length and ancestor IDs. It
 deliberately does not compare parent attrs, marks, sibling IDs, or indexes.
 
-`addMarks` applies the local Structure add suggestion and Structure move
-suggestion rules: provisional adds absorb later moves, Inverse moves on the same
-node cancel, and non-cancelling moves can still stack. See the provisional-adds
-and inverse moves ADR.
+`addMarks` classifies each mark's role, then applies the local Structure add
+suggestion and Structure move suggestion rules: provisional adds absorb later
+moves, Inverse moves on the same node cancel, and non-cancelling moves can still
+stack. See the provisional-adds and inverse moves ADR.
+
+Primary Structure marks are the user-visible source for a Structure suggestion.
+Supporting Structure marks record collateral structural movement inside the same
+suggestion ID. Supporting marks are still required for apply/revert; their role
+only changes presentation.
 
 Block join suggestions are suppressed when any joined node still has a Structure
 add mark. The physical join still happens, but the provisional add is treated as
@@ -226,11 +236,14 @@ A Structure mark is a node mark with attrs shaped like:
   id: SuggestionId;
   data: {
     op: Op;
+    role?: "primary" | "supporting";
   }
 }
 ```
 
 Use `guardStructureMarkAttrs` before trusting mark attrs loaded from a document.
+Role-less marks are treated as primary for compatibility with existing
+documents.
 
 `AddOp` means the marked node did not exist before and should be deleted on
 revert.

--- a/src/features/wrapUnwrap/docs/structure-changes-tracking.md
+++ b/src/features/wrapUnwrap/docs/structure-changes-tracking.md
@@ -1,0 +1,468 @@
+# Structure Changes Tracking
+
+Status: experimental, active hardening.
+
+This document explains the implementation of Structure suggestions in
+`src/features/wrapUnwrap`. It is meant to give a ProseMirror-proficient reader
+enough context to debug the current behavior, harden it, or extend it without
+breaking the core invariants.
+
+## Problem
+
+Text suggestions can be represented by retaining deleted content, marking
+inserted content, and tracking mark/attr changes. Structural context edits are
+different: indenting, outdenting, wrapping, unwrapping, and list input rules can
+destroy and recreate wrapper nodes while the human-visible content node
+survives.
+
+ProseMirror steps are also not semantic enough for this feature. A list split,
+indent, outdent, or blockquote wrap may arrive as `ReplaceStep` or
+`ReplaceAroundStep` operations whose positions describe the mutation but do not
+directly say "this paragraph moved from list item A to list item B" or "this
+paragraph moved into a blockquote." This feature therefore compares document
+structure before and after a transaction.
+
+## Decision
+
+Track structure edits by comparing stable node IDs and their materialized Parent
+chains before and after a transaction.
+
+The stable unit is the content/block node, not the structural context wrapper.
+Structure marks are added to content nodes such as paragraphs or headings.
+Configured Structural context path nodes are treated as structural context
+because they are often created, split, merged, or removed during the edit.
+
+## Scope
+
+This is not a general-purpose tree diff. Consumers configure the structural
+contexts they want to track with concrete ProseMirror node type names:
+
+```ts
+experimental_trackStructures: [
+  ["orderedList", "listItem"],
+  ["bulletList", "listItem"],
+  ["blockquote"],
+];
+```
+
+Each Structural context path is a contiguous parent-child ancestor path, not
+loose node-type membership. The expected list shape is:
+
+```text
+ListNode -> listItem -> block content
+```
+
+For blockquotes, the context shape is:
+
+```text
+blockquote -> block content
+```
+
+Nested configured structural contexts are supported. Same-parent reordering is
+not tracked yet.
+
+## Terminology Notes
+
+- "Suggestion" and "mark" are distinct: a Structure suggestion is the semantic
+  change group, while a Structure mark is the node-level marker in that group.
+- "Add mark" means Structure add suggestion in this document, not an inline
+  insertion mark.
+- Use Structural context path for consumer configuration and Parent chain for
+  runtime document location.
+
+## Core Algorithm
+
+1. Recognize any special compound transaction shape that must be split into
+   existing suggestion concepts before the normal structure/text branch.
+2. Ensure every non-text node has a stable unique ID.
+3. Build materialized Parent chains for the before-doc and after-doc.
+4. Ignore configured structural context nodes as Structure mark targets.
+5. For stable content nodes present in both docs:
+   - if the Parent chain changed, and either chain is a direct child of a
+     configured contiguous Structural context path, create a `move` op.
+6. For stable content nodes only present in the after-doc:
+   - if the node is non-empty and its raw text came from splitting an immediate
+     accepted sibling, return `reason: "split-derived-add"` so normal suggestion
+     tracking owns the transaction.
+   - if the after Parent chain is a direct child of a configured contiguous
+     Structural context path, create an `add` op.
+7. Add Structure marks to the affected content nodes.
+8. Applying removes Structure marks.
+9. Reverting uses stored Parent chains to delete added nodes or move existing
+   nodes back.
+
+## File Map
+
+- `structureChangesPlugin.ts`: transaction integration and structure diffing.
+- `buildMaterializedPaths.ts`: builds node ID to Parent chain maps.
+- `sameParentChain.ts`: compares Parent chains by ancestor IDs.
+- `types.ts`: operation, Parent chain, and Structure mark attr types.
+- `constants.ts`: structure tracking constants.
+- `addIdAttr.ts`: helper for adding an `id` attr to schema node specs.
+- `uniqueNodeIdsPlugin.ts`: demo/test ID-settling plugin and transform helper.
+- `apply/applyStructureSuggestions.ts`: accepts Structure suggestions by
+  removing Structure marks.
+- `revert/revertStructureSuggestions.ts`: grouped Structure suggestion revert
+  orchestration.
+- `revert/revertMoveOp.ts`: reconstructs previous Parent chains for moved nodes.
+- `revert/revertAddOp.ts`: deletes added nodes.
+- `revert/deleteNodeUpwards.ts`: prunes now-empty ancestors after deletion.
+- `../../transactionShaping`: recognizes special compound transactions before
+  the normal Structure-vs-text suggestion branch.
+- `__tests__/listStructure.playwright.test.ts`: user-level list behavior
+  coverage.
+- `__tests__/blockquoteStructure.playwright.test.ts`: user-level blockquote
+  behavior coverage.
+- `__tests__/splitDetection.test.ts`: focused coverage for split-derived add
+  fallthrough, including provisional Structure add cases.
+
+## Required Invariants
+
+- Every non-text document descendant that participates in structure tracking
+  must have a stable unique string `id` before structure detection runs. The
+  document root itself is represented by a synthetic `DOC_NODE_ID` parent.
+- Missing IDs should cause detection to bail rather than guess.
+- Duplicate IDs must be fixed before diffing; otherwise node correlation is
+  ambiguous. The primary `withSuggestChanges` integration can run the unique-ID
+  transform before structure detection; the append-transaction plugin expects
+  IDs to already be settled.
+- Structure marks belong on stable content/block nodes whose immediate parent
+  chain ends with a configured Structural context path. `getOps` skips nodes
+  whose type appears in a configured Structural context path.
+- A Structure add suggestion is still provisional new structure. Moving it must
+  not add Structure move suggestions until the add suggestion is accepted.
+- Stored parent descriptors must remain sufficient to recreate missing ancestor
+  wrappers and position the restored node near stable siblings.
+- Public apply/revert commands must set `suggestChangesKey` meta with
+  `{ skip: true }` so cleanup transactions are not tracked as new suggestions.
+
+## End-To-End Flow
+
+1. A user transaction changes the document while suggest changes is enabled.
+2. `withSuggestChanges` first gives the transaction-shaping layer a chance to
+   recognize special compound transactions. The current shaped case is TipTap's
+   paragraph-into-list Backspace transaction, which is expressed through
+   Structure tracking on the move prefix followed by normal join tracking on the
+   join suffix. This shaped move+join is one visible edit, so both tracking
+   paths receive the same suggestion ID. Provisional Structure adds can absorb
+   the move, and provisional add join cancellation can suppress the Block join
+   suggestion.
+3. In the primary `withSuggestChanges` integration, the dispatch wrapper uses
+   `experimental_ensureUniqueNodeIds` to set IDs on newly created or duplicated
+   nodes before structure diffing. The append-transaction plugin path only
+   checks for missing IDs and bails when IDs are not settled.
+4. `suggestStructureChanges(docBefore, docAfter, structuralContextPaths, generateId?)`
+   builds materialized paths for both docs.
+5. `getOps` compares paths by node ID and derives `move` or `add` operations.
+6. All structure ops from that detection pass share one suggestion ID.
+7. A transform over the after-doc updates `structure` node marks on affected
+   content nodes. It usually adds marks, but it can also remove an Inverse move.
+   The mark data stores the operation.
+8. If structure detection handled the transaction, the normal text-suggestion
+   transform is skipped for that transaction.
+9. Applying a Structure suggestion removes the Structure marks.
+10. Reverting a Structure suggestion uses the stored operation data to delete
+    added nodes or move existing nodes back to their previous Parent chain.
+
+## Materialized Paths
+
+`buildMaterializedPaths(doc)` returns a map:
+
+```ts
+Map<string, { nodeType: string; chain: Parent[] }>;
+```
+
+The key is a node ID. The Parent chain is immediate-parent-first and eventually
+ends in a special document parent:
+
+```ts
+{
+  nodeId: DOC_NODE_ID,
+  nodeType: DOC_NODE_ID,
+  nodeAttrs: {},
+  nodeMarks: [],
+  childSiblingIds: [leftSiblingId, rightSiblingId],
+  childIndex,
+}
+```
+
+For real parents, each descriptor stores:
+
+- parent node ID
+- parent node type
+- parent attrs
+- parent marks serialized to JSON
+- the child node's left and right sibling IDs in that parent
+- the child index
+
+Sibling IDs are primarily for stable revert placement. Raw indexes are stored
+for future work and debugging, but index shifts alone are not treated as moves.
+
+## Operation Detection
+
+`getOps(beforePaths, afterPaths, structuralContextPaths)` derives operations:
+
+- Existing non-context node with different Parent chain, and either old or new
+  Parent chain is a direct child of a configured Structural context path:
+  `move`.
+- Non-context node that exists only in the after-doc and whose Parent chain is a
+  direct child of a configured Structural context path: `add`.
+- Non-empty non-context node that exists only in the after-doc, or one of its
+  configured structural ancestors, whose raw text came from splitting an
+  immediate accepted sibling: not a Structure op; the transaction falls through
+  with `reason: "split-derived-add"`.
+- If that immediate previous sibling or its content descendants have a Structure
+  add mark in the before-doc, split-derived detection is skipped and the new
+  node remains a Structure add.
+- Node that exists only in the before-doc: ignored here; normal deletion
+  tracking handles deleted content.
+- Non-context node whose Parent chain IDs are unchanged: ignored, even if
+  sibling order or index changed.
+
+`sameParentChain` compares only Parent chain length and ancestor IDs. It
+deliberately does not compare parent attrs, marks, sibling IDs, or indexes.
+
+`addMarks` applies the local Structure add suggestion and Structure move
+suggestion rules: provisional adds absorb later moves, Inverse moves on the same
+node cancel, and non-cancelling moves can still stack. See
+[`0002-provisional-adds-and-inverse-moves.md`](adr/0002-provisional-adds-and-inverse-moves.md).
+
+Block join suggestions are suppressed when any joined node still has a Structure
+add mark. The physical join still happens, but the provisional add is treated as
+cancelled rather than creating a separate Block join suggestion.
+
+## Structure Mark Data
+
+A Structure mark is a node mark with attrs shaped like:
+
+```ts
+{
+  id: SuggestionId;
+  data: {
+    op: Op;
+  }
+}
+```
+
+Use `guardStructureMarkAttrs` before trusting mark attrs loaded from a document.
+
+`AddOp` means the marked node did not exist before and should be deleted on
+revert.
+
+`MoveOp` stores:
+
+- `from`: the node's Parent chain before the edit.
+- `to`: the node's Parent chain after the edit.
+
+The `from` chain is used to reconstruct the old location.
+
+## Block Join Suggestion Interaction
+
+Block joins normally insert a deletion-marked zero-width space with
+`type: "join"` so reverting can split the joined nodes and restore their node
+markup. New Block join suggestions serialize joined nodes as child-first
+`leftNodes` and `rightNodes` arrays, with one pair per joined depth up to the
+current maximum depth of 2. Legacy documents may still contain `leftNode` and
+`rightNode`; that shape is normalized to one-item arrays before revert.
+
+The marker is not created when any joined node has a Structure add mark before
+serialization. In that case the added structure is still provisional, so joining
+it away cancels the pending add without introducing another review artifact.
+When debugging this path, inspect the joined-node pairs that would be serialized
+in the Block join suggestion, not unrelated nodes in the deletion range.
+
+Rejecting a single Block join suggestion can reveal Structure marks that were
+serialized in its joined-node metadata. Single-suggestion rejection first
+rejects any restored Structure suggestion with the same suggestion ID as the
+Block join, then rejects the remaining restored Structure suggestion IDs. This
+preserves broad restored-Structure cleanup while giving shaped move+join
+semantic units priority.
+
+Reverting all suggestions applies the same rule to Block join suggestions before
+the generic all-suggestion cleanup. It rejects join suggestions as individual
+units so each join can clean up the Structure suggestions restored from its own
+metadata while the join-local restored positions are still meaningful. The later
+Structure cleanup pass handles any remaining Structure suggestions.
+
+## Applying Suggestions
+
+Applying a Structure suggestion accepts the structure edit. It does not move
+content. It removes matching `structure` marks. For range apply, the range
+selects suggestion IDs, then each selected Structure suggestion is applied as a
+whole group.
+
+## Reverting Suggestions
+
+Reverting a Structure suggestion uses the stored operation data to either delete
+added nodes or move existing nodes back to their previous Parent chain.
+Structure revert ordering is decision-owned by
+[`0001-structure-suggestion-revert-order.md`](adr/0001-structure-suggestion-revert-order.md).
+For range revert, the range selects suggestion IDs, then each selected Structure
+suggestion is reverted as a whole group.
+
+### Reverting `add`
+
+`revertAddOp` deletes the marked node and calls `deleteNodeUpwards` to prune
+ancestors that became empty.
+
+### Reverting `move`
+
+`revertMoveOp`:
+
+1. Finds the deepest still-existing ancestor from the stored `from` chain.
+2. Wraps the current node in the missing Parent chain with stored types, attrs,
+   and marks.
+3. Finds an insertion position in the surviving parent using the stored right
+   sibling, then left sibling, then end-of-parent fallback.
+4. Inserts or replaces with the reconstructed subtree.
+5. Maps the original moved-node position through `tr.mapping`.
+6. Deletes the moved node from its current location and prunes empty ancestors.
+
+### Empty Ancestor Pruning
+
+`deleteNodeUpwards` expands the deletion range upward while the parent has
+exactly one child, namely the node being removed. This avoids leaving empty
+`listItem` or list nodes that violate the schema.
+
+## Integration
+
+There are two integration paths:
+
+- `withSuggestChanges`: the important experimental path. It can run structure
+  detection first when `experimental_trackStructureChanges`,
+  `experimental_trackStructures`, and `experimental_ensureUniqueNodeIds` are
+  provided. If structure detection handles the transaction, the normal
+  suggestion transform is skipped for that transaction.
+- `structureChangesPlugin`: an append-transaction plugin path that also compares
+  old and new docs with the same `experimental_trackStructures` config, but is
+  not the primary path for current hardening.
+
+Before either the normal structure-first path or the normal text-suggestion path
+runs, `withSuggestChanges` asks transaction shaping to handle recognized
+compound transactions. The shaped TipTap paragraph-into-list join path runs
+Structure detection on the move prefix, then runs normal text suggestion
+tracking on the join suffix with the same generated suggestion ID. If the moved
+node already has a Structure add suggestion, that add can satisfy the shaped
+prefix without producing a separate Structure move mark.
+
+`suggestStructureChanges` returns `{ handled, transform, reason? }`. `handled`
+is based on whether structure ops were detected, not whether the transform
+contains steps. This distinction matters when every detected op is intentionally
+suppressed, such as moving a node that still has a Structure add suggestion.
+Inverse moves are also handled by structure tracking, but they remove an
+existing mark and therefore can still produce transform steps.
+`reason: "split-derived-add"` means a newly materialized content node came from
+splitting an immediate accepted sibling; the primary `withSuggestChanges` path
+lets the normal suggestion transform own the whole transaction.
+`withSuggestChanges` uses `handled` to avoid falling back to normal text
+suggestion tracking for a transaction structure tracking already understood.
+
+Structure tracking should be skipped for transactions from history, collab, yjs
+undo/redo, yjs change origin, or transactions carrying `suggestChangesKey` skip
+meta.
+
+## Why Not Use Step Interpretation?
+
+Do not try to infer structural context semantics only from `ReplaceStep` or
+`ReplaceAroundStep`. Those steps describe positional replacement mechanics, not
+the semantic intent. Comparing materialized paths answers the question this
+feature needs: "where was node X before, and where is node X now?"
+
+## Why Not Mark Structural Context Nodes?
+
+Structural context nodes are not stable across edits. ProseMirror commands may
+split, join, remove, or recreate list wrappers, list items, and blockquotes. The
+content node, identified by stable ID, is the thing a user experiences as "the
+item that moved." Marking content nodes makes suggestions survive structural
+churn.
+
+## Extending The Feature
+
+When adding support for another structural edit or node family, review all of
+these areas together:
+
+- Node ID coverage: every relevant non-text node must get stable unique IDs.
+- Detection scope: add a Structural context path made of concrete ProseMirror
+  node type names.
+- Schema assumptions: define the expected parent/child shape and invalid
+  intermediate states.
+- Mark target: choose the stable node that survives the structural edit.
+- Operation data: store enough information to revert without relying on fragile
+  positions.
+- Revert reconstruction: ensure missing ancestors can be recreated with attrs
+  and marks.
+- Insertion placement: prefer stable sibling IDs over raw indexes.
+- Apply/revert commands: preserve skip meta.
+- Tests: cover user-level commands, not only low-level transforms.
+
+For same-parent reorder support, do not compare raw child indexes directly and
+call it done. Indexes shift when siblings are inserted or deleted. Use relative
+ordering of surviving sibling IDs or another stable ordering model.
+
+## Debugging Checklist
+
+When structure tracking does not behave as expected:
+
+- Confirm suggest changes mode is enabled and the transaction is not skipped by
+  history/collab/yjs/skip meta.
+- Confirm all relevant nodes have unique string `id` attrs before
+  `suggestStructureChanges` runs.
+- Inspect `buildMaterializedPaths` output for the moved node in both docs.
+- Check whether `sameParentChain` returns true; if so, detection will not create
+  a move.
+- Confirm at least one Parent chain is a direct child of a configured contiguous
+  Structural context path.
+- Inspect the added `structure` mark and validate it with
+  `guardStructureMarkAttrs`.
+- For unexpected Structure add suggestions, inspect the candidate previous
+  sibling IDs, the previous sibling subtree's before-doc Structure marks, and
+  the raw text comparison used to detect split-derived content.
+- For failed reverts, inspect `op.from`, `op.to`, the current Parent chain, and
+  whether the stored parent node types still exist in the schema.
+- Check whether insertion chose right sibling, left sibling, or end-of-parent
+  fallback.
+- Verify `tr.mapping.map(pos)` is used before deleting the current moved node
+  after insertion.
+- Look for schema errors caused by recreating parents that no longer accept the
+  child node.
+
+## Current Limitations / Risks
+
+- Experimental configured structural context tracking only; not a complete
+  structural diff engine.
+- Configured node names are not runtime-validated against the schema.
+- Same-parent reorder is not tracked.
+- Parent chain equality only compares ancestor IDs and chain length.
+- Schema-invalid reconstruction can throw or fail a ProseMirror step.
+- Revert can be lossy if stored parent node types, attrs, or marks no longer
+  exist or no longer accept the child being restored.
+- Structure marks are node marks. Integrations that only handle inline mark
+  steps will miss them.
+- The implementation currently contains verbose tracing and console logging;
+  consider noise and performance when hardening production paths.
+
+## Test Guidance
+
+Prefer scenario tests around user-observable behavior:
+
+- single indent and outdent
+- top, middle, and last list items
+- nested list outdent
+- multi-item indent and outdent
+- multiple sequential Structure suggestions
+- outdenting from a list into the root document
+- wrapping and unwrapping content in blockquotes
+- nested configured structural contexts, such as blockquote content containing
+  lists
+- creating bullet and ordered lists through input rules
+- applying and reverting individual suggestions
+- applying and reverting all suggestions
+- missing IDs and duplicate IDs
+- copied/pasted content and list-item splits
+- stacked Structure marks on the same content node
+
+When changing revert reconstruction, include tests where siblings are missing so
+right-sibling, left-sibling, and end-of-parent placement paths are exercised.
+
+Keep this package app-agnostic. Do not add consuming application details or
+application-specific metadata assumptions here.

--- a/src/features/wrapUnwrap/docs/structure-changes-tracking.md
+++ b/src/features/wrapUnwrap/docs/structure-changes-tracking.md
@@ -2,10 +2,9 @@
 
 Status: experimental, active hardening.
 
-This document explains the implementation of Structure suggestions in
-`src/features/wrapUnwrap`. It is meant to give a ProseMirror-proficient reader
-enough context to debug the current behavior, harden it, or extend it without
-breaking the core invariants.
+This document explains the plugin implementation of Structure suggestions. It is
+meant to give a ProseMirror-proficient reader enough context to debug the
+current behavior, harden it, or extend it without breaking the core invariants.
 
 ## Problem
 
@@ -91,30 +90,17 @@ not tracked yet.
 9. Reverting uses stored Parent chains to delete added nodes or move existing
    nodes back.
 
-## File Map
+## Code Areas
 
-- `structureChangesPlugin.ts`: transaction integration and structure diffing.
-- `buildMaterializedPaths.ts`: builds node ID to Parent chain maps.
-- `sameParentChain.ts`: compares Parent chains by ancestor IDs.
-- `types.ts`: operation, Parent chain, and Structure mark attr types.
-- `constants.ts`: structure tracking constants.
-- `addIdAttr.ts`: helper for adding an `id` attr to schema node specs.
-- `uniqueNodeIdsPlugin.ts`: demo/test ID-settling plugin and transform helper.
-- `apply/applyStructureSuggestions.ts`: accepts Structure suggestions by
-  removing Structure marks.
-- `revert/revertStructureSuggestions.ts`: grouped Structure suggestion revert
-  orchestration.
-- `revert/revertMoveOp.ts`: reconstructs previous Parent chains for moved nodes.
-- `revert/revertAddOp.ts`: deletes added nodes.
-- `revert/deleteNodeUpwards.ts`: prunes now-empty ancestors after deletion.
-- `../../transactionShaping`: recognizes special compound transactions before
-  the normal Structure-vs-text suggestion branch.
-- `__tests__/listStructure.playwright.test.ts`: user-level list behavior
-  coverage.
-- `__tests__/blockquoteStructure.playwright.test.ts`: user-level blockquote
-  behavior coverage.
-- `__tests__/splitDetection.test.ts`: focused coverage for split-derived add
-  fallthrough, including provisional Structure add cases.
+The structure-tracking implementation is split across these stable areas:
+
+- transaction integration and structure diffing
+- materialized Parent chain construction and comparison
+- Structure mark attrs and operation guards
+- unique-node-ID settling
+- Structure suggestion apply/revert commands
+- transaction shaping for compound editor transactions
+- user-level list, blockquote, split, apply, and revert coverage
 
 ## Required Invariants
 
@@ -224,8 +210,8 @@ deliberately does not compare parent attrs, marks, sibling IDs, or indexes.
 
 `addMarks` applies the local Structure add suggestion and Structure move
 suggestion rules: provisional adds absorb later moves, Inverse moves on the same
-node cancel, and non-cancelling moves can still stack. See
-[`0002-provisional-adds-and-inverse-moves.md`](adr/0002-provisional-adds-and-inverse-moves.md).
+node cancel, and non-cancelling moves can still stack. See the provisional-adds
+and inverse moves ADR.
 
 Block join suggestions are suppressed when any joined node still has a Structure
 add mark. The physical join still happens, but the provisional add is treated as
@@ -295,10 +281,9 @@ whole group.
 
 Reverting a Structure suggestion uses the stored operation data to either delete
 added nodes or move existing nodes back to their previous Parent chain.
-Structure revert ordering is decision-owned by
-[`0001-structure-suggestion-revert-order.md`](adr/0001-structure-suggestion-revert-order.md).
-For range revert, the range selects suggestion IDs, then each selected Structure
-suggestion is reverted as a whole group.
+Structure revert ordering is decision-owned by the Structure suggestion revert
+order ADR. For range revert, the range selects suggestion IDs, then each
+selected Structure suggestion is reverted as a whole group.
 
 ### Reverting `add`
 

--- a/src/features/wrapUnwrap/generateUniqueNodeId.ts
+++ b/src/features/wrapUnwrap/generateUniqueNodeId.ts
@@ -1,0 +1,9 @@
+export function generateUniqueNodeId() {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return `node-${Math.random().toString(36).slice(2)}`;
+}

--- a/src/features/wrapUnwrap/getNodeId.ts
+++ b/src/features/wrapUnwrap/getNodeId.ts
@@ -1,0 +1,7 @@
+import { type Node } from "prosemirror-model";
+
+export function getNodeId(node: Node) {
+  const nodeId = node.attrs["id"] as unknown;
+  if (typeof nodeId !== "string") return null;
+  return nodeId;
+}

--- a/src/features/wrapUnwrap/revert/deleteNodeUpwards.ts
+++ b/src/features/wrapUnwrap/revert/deleteNodeUpwards.ts
@@ -1,0 +1,96 @@
+import { type Transform } from "prosemirror-transform";
+import { type Node } from "prosemirror-model";
+import { getNodeId } from "../getNodeId.js";
+
+const TRACE_ENABLED = false;
+function trace(...args: unknown[]) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!TRACE_ENABLED) return;
+  console.log("[deleteNodeUpwards]", "\n", ...args);
+}
+
+// delete a given node, and traverse upwards deleting parent nodes if they are now empty
+export function deleteNodeUpwards(
+  transform: Transform,
+  node: Node,
+  pos: number,
+) {
+  let $mappedPos = transform.doc.resolve(pos);
+  trace(
+    "attempting to delete node",
+    node.type.name,
+    getNodeId(node),
+    "\n",
+    "node subtree:\n",
+    node.toString(),
+    "\n",
+    "node parent:",
+    $mappedPos.parent.type.name,
+    getNodeId($mappedPos.parent),
+    "\n",
+    { node, parent: $mappedPos.parent },
+  );
+
+  let deleteFrom = $mappedPos.pos;
+  let deleteTo = $mappedPos.pos + node.nodeSize;
+
+  while ($mappedPos.depth > 0) {
+    const $nextMappedPos = transform.doc.resolve($mappedPos.before());
+    if ($nextMappedPos.nodeAfter?.childCount !== 1) {
+      trace(
+        "stopping deletion at non-empty node:",
+        $nextMappedPos.nodeAfter?.type.name,
+        $nextMappedPos.nodeAfter == null
+          ? null
+          : getNodeId($nextMappedPos.nodeAfter),
+        "\n",
+        "non-empty node parent:",
+        $nextMappedPos.parent.type.name,
+        getNodeId($nextMappedPos.parent),
+        "\n",
+        "non-empty node subtree:\n",
+        $nextMappedPos.nodeAfter?.toString(),
+        "\n",
+        "non-empty node subtree direct children:\n",
+        $nextMappedPos.nodeAfter?.children
+          .map((child) => `${child.type.name} ${getNodeId(child) ?? "null"}`)
+          .join(", "),
+        {
+          nonEmptyNode: $nextMappedPos.nodeAfter,
+          nonEmptyNodeParent: $nextMappedPos.parent,
+        },
+      );
+      break;
+    }
+
+    $mappedPos = $nextMappedPos;
+    deleteFrom = $nextMappedPos.pos;
+    deleteTo = $nextMappedPos.pos + $nextMappedPos.nodeAfter.nodeSize;
+  }
+
+  trace(
+    "deleting subtree:\n",
+    $mappedPos.nodeAfter?.toString(),
+    "\n",
+    "subtree root node:",
+    $mappedPos.nodeAfter?.type.name,
+    $mappedPos.nodeAfter == null ? null : getNodeId($mappedPos.nodeAfter),
+    "\n",
+    "subtree root parent node:",
+    $mappedPos.parent.type.name,
+    getNodeId($mappedPos.parent),
+    "\n",
+    "non-empty node subtree direct children:\n",
+    $mappedPos.nodeAfter?.children
+      .map((child) => `${child.type.name} (${getNodeId(child) ?? "null"}`)
+      .join(", "),
+    "\n",
+    {
+      node: $mappedPos.nodeAfter,
+      parent: $mappedPos.parent,
+      $deleteFrom: $mappedPos.doc.resolve(deleteFrom),
+      $deleteTo: $mappedPos.doc.resolve(deleteTo),
+    },
+  );
+  transform.delete(deleteFrom, deleteTo);
+}

--- a/src/features/wrapUnwrap/revert/deleteNodeUpwards.ts
+++ b/src/features/wrapUnwrap/revert/deleteNodeUpwards.ts
@@ -9,7 +9,6 @@ function trace(...args: unknown[]) {
   console.log("[deleteNodeUpwards]", "\n", ...args);
 }
 
-// delete a given node, and traverse upwards deleting parent nodes if they are now empty
 export function deleteNodeUpwards(
   transform: Transform,
   node: Node,
@@ -34,6 +33,9 @@ export function deleteNodeUpwards(
   let deleteFrom = $mappedPos.pos;
   let deleteTo = $mappedPos.pos + node.nodeSize;
 
+  // Structure marks live on content nodes, but added wrappers can become empty
+  // after that content is removed. Delete upward until the next parent still has
+  // another child that should survive.
   while ($mappedPos.depth > 0) {
     const $nextMappedPos = transform.doc.resolve($mappedPos.before());
     if ($nextMappedPos.nodeAfter?.childCount !== 1) {

--- a/src/features/wrapUnwrap/revert/index.ts
+++ b/src/features/wrapUnwrap/revert/index.ts
@@ -1,0 +1,23 @@
+import { Transform } from "prosemirror-transform";
+import { revertStructureSuggestionsInDoc } from "./revertStructureSuggestions.js";
+import { type Node } from "prosemirror-model";
+import { type SuggestionId } from "../../../generateId.js";
+
+export function revertAllStructureSuggestions(
+  doc: Node,
+  from?: number,
+  to?: number,
+) {
+  const tr = new Transform(doc);
+  revertStructureSuggestionsInDoc({ tr, from, to });
+  return tr;
+}
+
+export function revertStructureSuggestion(
+  doc: Node,
+  suggestionId: SuggestionId,
+) {
+  const tr = new Transform(doc);
+  revertStructureSuggestionsInDoc({ tr, suggestionId });
+  return tr;
+}

--- a/src/features/wrapUnwrap/revert/revertAddOp.ts
+++ b/src/features/wrapUnwrap/revert/revertAddOp.ts
@@ -1,0 +1,13 @@
+import { type Transform } from "prosemirror-transform";
+import { type AddOp } from "../types.js";
+import { deleteNodeUpwards } from "./deleteNodeUpwards.js";
+import { type Node } from "prosemirror-model";
+
+export function revertAddOp(
+  _op: AddOp,
+  tr: Transform,
+  node: Node,
+  pos: number,
+) {
+  deleteNodeUpwards(tr, node, pos);
+}

--- a/src/features/wrapUnwrap/revert/revertAddOp.ts
+++ b/src/features/wrapUnwrap/revert/revertAddOp.ts
@@ -9,5 +9,7 @@ export function revertAddOp(
   node: Node,
   pos: number,
 ) {
+  // A Structure add marks the content node, but reverting it may also need to
+  // remove now-empty structural parents that only existed to contain it.
   deleteNodeUpwards(tr, node, pos);
 }

--- a/src/features/wrapUnwrap/revert/revertMoveOp.ts
+++ b/src/features/wrapUnwrap/revert/revertMoveOp.ts
@@ -1,0 +1,166 @@
+import { type Transform } from "prosemirror-transform";
+import { type MoveOp } from "../types.js";
+import { type Node } from "prosemirror-model";
+import { deleteNodeUpwards } from "./deleteNodeUpwards.js";
+import { getNodeId } from "../getNodeId.js";
+import { type Parent } from "../types.js";
+
+export function revertMoveOp(
+  op: MoveOp,
+  tr: Transform,
+  node: Node,
+  pos: number,
+) {
+  const parent = getDeepestSurvivingParent(op.from, tr.doc);
+
+  const child = wrapNodeInParentChain(parent.remainingChain, node);
+  const insertTo = findInsertionPos(
+    parent.node,
+    parent.pos,
+    parent.parent,
+    child,
+  );
+
+  if (typeof insertTo === "number") {
+    tr.insert(insertTo, child);
+  } else {
+    tr.replaceWith(insertTo.from, insertTo.to, child);
+  }
+
+  const mappedPos = tr.mapping.map(pos);
+  deleteNodeUpwards(tr, node, mappedPos);
+}
+
+// given a chain of parent node descriptors, follow the chain from top to bottom as long as nodes exist
+// return the deepest existing parent node descriptor, along with the actual node and the pos in the current document
+// also return the remaining part of the chain
+export function getDeepestSurvivingParent(parentChain: Parent[], doc: Node) {
+  const chain = [...parentChain].reverse();
+
+  const root = chain.shift();
+  if (root == null) {
+    throw new Error("Parent chain is empty");
+  }
+
+  let result: { parent: Parent; node: Node; pos: number | null } = {
+    parent: root,
+    node: doc,
+    pos: null,
+  };
+
+  let remainingChain: Parent[] = [...chain];
+
+  // follow the chain up-down
+  // look for the node with the matching id in the children of the previously found node
+  for (const [index, item] of chain.entries()) {
+    let found = false as boolean;
+
+    result.node.forEach((child, offset) => {
+      if (found) return;
+      if (child.attrs["id"] !== item.nodeId) return;
+
+      found = true;
+      const pos = result.pos == null ? offset : result.pos + 1 + offset;
+      result = {
+        parent: item,
+        node: child,
+        pos,
+      };
+      remainingChain = chain.slice(index + 1);
+    });
+
+    if (!found) break;
+  }
+
+  return {
+    parent: result.parent,
+    node: result.node,
+    pos: result.pos,
+    remainingChain: remainingChain.reverse(),
+  };
+}
+
+// given a chain of parent node descriptors and a node
+// wrap the node in the parent chain
+export function wrapNodeInParentChain(parentChain: Parent[], node: Node) {
+  let child = node.copy(node.content);
+
+  for (const parent of parentChain) {
+    const schema = node.type.schema;
+
+    const nodeType = schema.nodes[parent.nodeType];
+    if (!nodeType) {
+      throw new Error(`node type ${parent.nodeType} not found in schema`);
+    }
+
+    const marks = parent.nodeMarks.map((mark) => schema.markFromJSON(mark));
+
+    const parentNode = nodeType.createAndFill(parent.nodeAttrs, child, marks);
+    if (parentNode == null)
+      throw new Error(
+        `Unable to create node ${nodeType.name} with child ${child.toString()}`,
+      );
+
+    child = parentNode;
+    child.check();
+  }
+
+  return child;
+}
+
+// given a node, its position, and a parent descriptor of this node in some parent chain,
+// use the info from the descriptor to find the insertion position in the node
+// first try to find siblings, fallback to end of node
+export function findInsertionPos(
+  node: Node,
+  pos: number | null,
+  parent: Parent,
+  child: Node,
+) {
+  let leftSibling = null as { node: Node; pos: number } | null;
+  let rightSibling = null as { node: Node; pos: number } | null;
+
+  node.descendants((child, localChildPos) => {
+    const childId = getNodeId(child);
+    if (childId == null) return false;
+
+    const globalChildPos =
+      pos != null ? pos + 1 + localChildPos : localChildPos;
+
+    if (parent.childSiblingIds[0] === childId) {
+      leftSibling = { node: child, pos: globalChildPos };
+    }
+
+    if (parent.childSiblingIds[1] === childId) {
+      rightSibling = { node: child, pos: globalChildPos };
+    }
+
+    // iterate only direct children
+    return false;
+  });
+
+  if (rightSibling != null) {
+    // special case: we need to insert as the first child, but the existing first child is an empty node of the same type
+    // in this case, we need to replace the existing first child with the new node
+    const firstChild = node.children[0];
+    if (
+      parent.childSiblingIds[0] == null &&
+      firstChild?.type === child.type &&
+      firstChild.textContent === ""
+    ) {
+      const from = pos != null ? pos + 1 : 0;
+      return { from, to: from + firstChild.nodeSize };
+    }
+
+    // insert before right sibling
+    return rightSibling.pos;
+  }
+
+  if (leftSibling != null) {
+    // insert after left sibling
+    return leftSibling.pos + leftSibling.node.nodeSize;
+  }
+
+  // insert at end of node
+  return pos != null ? pos + node.nodeSize - 1 : node.content.size;
+}

--- a/src/features/wrapUnwrap/revert/revertMoveOp.ts
+++ b/src/features/wrapUnwrap/revert/revertMoveOp.ts
@@ -11,6 +11,8 @@ export function revertMoveOp(
   node: Node,
   pos: number,
 ) {
+  // The original parent chain may have been partially removed since the move.
+  // Reuse the deepest surviving parent and recreate only the missing wrappers.
   const parent = getDeepestSurvivingParent(op.from, tr.doc);
 
   const child = wrapNodeInParentChain(parent.remainingChain, node);
@@ -140,8 +142,9 @@ export function findInsertionPos(
   });
 
   if (rightSibling != null) {
-    // special case: we need to insert as the first child, but the existing first child is an empty node of the same type
-    // in this case, we need to replace the existing first child with the new node
+    // If the original first-child slot is now occupied by an empty placeholder
+    // of the same type, replace it instead of inserting beside it. This avoids
+    // leaving a blank node where the moved content should be restored.
     const firstChild = node.children[0];
     if (
       parent.childSiblingIds[0] == null &&

--- a/src/features/wrapUnwrap/revert/revertStructureSuggestions.ts
+++ b/src/features/wrapUnwrap/revert/revertStructureSuggestions.ts
@@ -222,6 +222,9 @@ function buildOrderedSuggestionIds(
   const suggestionIds = new Set<SuggestionId>();
   suggestionIds.add(suggestionId);
 
+  // If this move is no longer at its expected destination, another Structure
+  // move must be reverted first. Build the dependency chain so reverts happen
+  // from the current outermost state back toward the requested suggestion.
   // find first mark that doesn't have a matching op.to
   const mismatch = markGroup.find((mark) => {
     const nodeId = getNodeId(mark.node);

--- a/src/features/wrapUnwrap/revert/revertStructureSuggestions.ts
+++ b/src/features/wrapUnwrap/revert/revertStructureSuggestions.ts
@@ -1,0 +1,342 @@
+import { type Node } from "prosemirror-model";
+import { getSuggestionMarks } from "../../../utils.js";
+import { type Mark } from "prosemirror-model";
+import { getNodeId } from "../getNodeId.js";
+import { Transform } from "prosemirror-transform";
+import { type SuggestionId } from "../../../generateId.js";
+import { guardStructureMarkAttrs, type MaterializedPaths } from "../types.js";
+import { sameParentChain } from "../sameParentChain.js";
+import { buildMaterializedPaths } from "../buildMaterializedPaths.js";
+import { revertAddOp } from "./revertAddOp.js";
+import { revertMoveOp } from "./revertMoveOp.js";
+
+const TRACE_ENABLED = false;
+function trace(...args: unknown[]) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!TRACE_ENABLED) return;
+  console.log("[revertStructureSuggestions]", ...args);
+}
+
+export function revertStructureSuggestionsInDoc({
+  tr,
+  suggestionId,
+  from,
+  to,
+}: {
+  tr: Transform;
+  suggestionId?: SuggestionId;
+  from?: number | undefined;
+  to?: number | undefined;
+}) {
+  if (suggestionId) {
+    // when suggestionId is given, just revert it, no other logic required
+    revertStructureSuggestionWithPrerequisites(tr, suggestionId);
+    return;
+  }
+
+  if (from || to) {
+    // when range is given, find suggestion ids inside that range,
+    // but make sure to revert furthermost suggestions first
+    // todo: most likely a better strategy would be to search for the next suggestion in the updated doc after each reversal (and map from and to)
+    const { structure } = getSuggestionMarks(tr.doc.type.schema);
+
+    const structureMarks: { mark: Mark; node: Node; pos: number }[] = [];
+
+    tr.doc.descendants((node, pos) => {
+      if (from !== undefined && pos < from) {
+        return true;
+      }
+      if (to !== undefined && pos > to) {
+        return false;
+      }
+
+      if (node.isText) return true;
+      if (!structure.isInSet(node.marks)) return true;
+
+      node.marks.forEach((mark) => {
+        if (mark.type !== structure) return;
+        structureMarks.push({ mark, node, pos });
+      });
+
+      return true;
+    });
+
+    structureMarks.sort((a, b) => b.pos - a.pos);
+
+    const suggestionIds = new Set<SuggestionId>();
+    structureMarks.forEach(({ mark }) => {
+      suggestionIds.add(mark.attrs["id"] as SuggestionId);
+    });
+
+    for (const suggestionId of suggestionIds) {
+      revertStructureSuggestionWithPrerequisites(tr, suggestionId);
+    }
+
+    return;
+  }
+
+  // if no suggestion id nor range is given, revert all suggestions one by one, always take furthermost first
+  // after each reversal, the next suggestion is searched in the new doc after the previous reversal
+  let nextSuggestionId = findNextStructureSuggestion(tr.doc);
+  while (nextSuggestionId != null) {
+    revertStructureSuggestionWithPrerequisites(tr, nextSuggestionId);
+    nextSuggestionId = findNextStructureSuggestion(tr.doc);
+  }
+}
+
+function revertStructureSuggestionWithPrerequisites(
+  tr: Transform,
+  suggestionId: SuggestionId,
+) {
+  const suggestionIds = buildOrderedSuggestionIds(
+    tr.doc,
+    suggestionId,
+    buildMaterializedPaths(tr.doc),
+  );
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (TRACE_ENABLED)
+    console.group("reverting structure suggestions", suggestionIds);
+  for (const suggestionId of suggestionIds) {
+    revertOneStructureSuggestion(tr, suggestionId);
+  }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (TRACE_ENABLED) console.groupEnd();
+}
+
+function revertOneStructureSuggestion(
+  tr: Transform,
+  suggestionId: SuggestionId,
+) {
+  let count = 0;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (TRACE_ENABLED)
+    console.groupCollapsed("reverting structure suggestion", suggestionId);
+  let structureMark = findNextStructureMark(tr.doc, suggestionId);
+  while (structureMark !== null) {
+    trace(
+      "reverting structure suggestion",
+      suggestionId,
+      "structure mark",
+      structureMark.mark,
+      "at pos",
+      structureMark.pos,
+      "at node",
+      structureMark.node.toString(),
+    );
+    revertStructureMark(tr, structureMark.mark, structureMark.pos);
+    structureMark = findNextStructureMark(tr.doc, suggestionId);
+    count++;
+  }
+  trace("reverted", count, "structure marks for suggestion", suggestionId);
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (TRACE_ENABLED) console.groupEnd();
+}
+
+export function revertStructureMark(tr: Transform, mark: Mark, pos: number) {
+  const transform = new Transform(tr.doc);
+  transform.removeNodeMark(pos, mark);
+
+  const node = transform.doc.nodeAt(pos);
+  if (!node) {
+    throw new Error(`Node not found at position ${String(pos)}`);
+  }
+
+  const attrs = mark.attrs;
+  if (!guardStructureMarkAttrs(attrs)) {
+    console.warn(
+      "revertStructureMark",
+      "invalid shape of structure mark attrs",
+      { attrs },
+    );
+    return;
+  }
+
+  const op = attrs.data.op;
+
+  trace(
+    "reverting structure mark with suggestion id",
+    attrs.id,
+    "at node",
+    node.toString(),
+    "at pos",
+    pos,
+    "with op",
+    op.op,
+    {
+      mark,
+      node,
+      $pos: transform.doc.resolve(pos),
+      op,
+    },
+  );
+
+  switch (op.op) {
+    case "add": {
+      revertAddOp(op, transform, node, pos);
+      break;
+    }
+    case "move": {
+      revertMoveOp(op, transform, node, pos);
+      break;
+    }
+    default:
+      console.warn("revertStructureMark", "unknown op", { op });
+      break;
+  }
+
+  transform.steps.forEach((step) => {
+    tr.step(step);
+  });
+}
+
+// given a suggestion id
+// return an array of suggestion ids to revert
+// resolve suggestion dependencies, meaning,
+// if to revert suggestion id 1 you need to revert 2, and to revert 2 you need to revert 3
+// it will return [3,2,1]
+// todo: this should probably use topological sort at some point
+function buildOrderedSuggestionIds(
+  node: Node,
+  suggestionId: SuggestionId,
+  materializedPaths: MaterializedPaths,
+) {
+  const { structure } = getSuggestionMarks(node.type.schema);
+
+  // collect marks with the given suggestionId
+  const markGroup: { mark: Mark; node: Node; pos: number }[] = [];
+
+  node.descendants((descendant, pos) => {
+    if (descendant.isText) return true;
+    if (!structure.isInSet(descendant.marks)) return true;
+
+    descendant.marks.forEach((mark) => {
+      if (mark.type !== structure) return;
+      if (mark.attrs["id"] !== suggestionId) return;
+
+      markGroup.push({ mark, node: descendant, pos });
+    });
+
+    return true;
+  });
+
+  const suggestionIds = new Set<SuggestionId>();
+  suggestionIds.add(suggestionId);
+
+  // find first mark that doesn't have a matching op.to
+  const mismatch = markGroup.find((mark) => {
+    const nodeId = getNodeId(mark.node);
+    if (nodeId == null) return false;
+
+    const parentChain = materializedPaths.get(nodeId);
+    if (parentChain == null) return false;
+
+    const { attrs } = mark.mark;
+    if (!guardStructureMarkAttrs(attrs)) return false;
+
+    if (attrs.data.op.op !== "move") return false;
+
+    return !sameParentChain(attrs.data.op.to, parentChain.chain);
+  });
+
+  if (mismatch == null) {
+    return Array.from(suggestionIds).reverse();
+  }
+
+  // find first mark on the node that does have a matching op.to
+  const match = mismatch.node.marks.find((mark) => {
+    if (mark.type !== structure) return false;
+
+    const { attrs } = mark;
+    if (!guardStructureMarkAttrs(attrs)) return false;
+
+    if (attrs.data.op.op !== "move") return false;
+
+    const nodeId = getNodeId(mismatch.node);
+    if (nodeId == null) return false;
+
+    const parentChain = materializedPaths.get(nodeId);
+    if (parentChain == null) return false;
+
+    return sameParentChain(attrs.data.op.to, parentChain.chain);
+  });
+
+  if (match) {
+    trace(
+      "suggestion",
+      match.attrs["id"],
+      "is a prerequisite for suggestion",
+      suggestionId,
+    );
+    suggestionIds.add(match.attrs["id"] as SuggestionId);
+  }
+
+  return Array.from(suggestionIds).reverse();
+}
+
+function findNextStructureSuggestion(doc: Node): SuggestionId | null {
+  const { structure } = getSuggestionMarks(doc.type.schema);
+
+  const structureMarks: { mark: Mark; node: Node; pos: number }[] = [];
+
+  doc.descendants((node, pos) => {
+    if (node.isText) return true;
+    if (!structure.isInSet(node.marks)) return true;
+
+    node.marks.forEach((mark) => {
+      if (mark.type !== structure) return;
+      structureMarks.push({ mark, node, pos });
+    });
+
+    return true;
+  });
+
+  structureMarks.sort((a, b) => b.pos - a.pos);
+
+  return structureMarks[0]?.mark.attrs["id"] as SuggestionId | null;
+}
+
+// given a suggestion id, find next structure mark to revert that belongs to that suggestion
+// always take furthermost mark first
+function findNextStructureMark(node: Node, suggestionId: SuggestionId) {
+  const { structure } = getSuggestionMarks(node.type.schema);
+
+  const structureMarks: {
+    mark: Mark;
+    node: Node;
+    pos: number;
+  }[] = [];
+
+  node.descendants((descendant, pos) => {
+    // the assumption here is that a single node cannot have multiple structure marks with the same suggestion id
+    // check the invariant
+    const suggestionIds = new Set<SuggestionId>();
+    descendant.marks.forEach((mark) => {
+      if (mark.type !== structure) return;
+      const markSuggestionId = mark.attrs["id"] as SuggestionId;
+      if (suggestionIds.has(markSuggestionId)) {
+        console.warn(
+          "node",
+          node,
+          "has multiple structure marks with the same suggestion id",
+          markSuggestionId,
+        );
+      }
+      suggestionIds.add(markSuggestionId);
+    });
+
+    const mark = descendant.marks.find(
+      (mark) => mark.type === structure && mark.attrs["id"] === suggestionId,
+    );
+    if (mark == null) return true;
+    structureMarks.push({
+      mark,
+      node: descendant,
+      pos,
+    });
+    return true;
+  });
+
+  structureMarks.sort((a, b) => b.pos - a.pos);
+
+  return structureMarks[0] ?? null;
+}

--- a/src/features/wrapUnwrap/sameParentChain.ts
+++ b/src/features/wrapUnwrap/sameParentChain.ts
@@ -1,0 +1,11 @@
+import { type Parent } from "./types.js";
+
+export function sameParentChain(
+  parentChainA: Parent[],
+  parentChainB: Parent[],
+) {
+  if (parentChainA.length !== parentChainB.length) return false;
+  return parentChainA.every(
+    (parent, index) => parent.nodeId === parentChainB[index]?.nodeId,
+  );
+}

--- a/src/features/wrapUnwrap/structureChangesPlugin.ts
+++ b/src/features/wrapUnwrap/structureChangesPlugin.ts
@@ -15,6 +15,7 @@ import {
   type MaterializedPaths,
   type Parent,
   type StructuralContextPath,
+  type StructureMarkRole,
 } from "./types.js";
 import { DOC_NODE_ID, STRUCTURE_CHANGES_ADD_MARKS } from "./constants.js";
 import { Transform } from "prosemirror-transform";
@@ -218,7 +219,8 @@ export function suggestStructureChanges(
     return { handled: false, transform, reason };
   }
 
-  addMarks(ops, transform, suggestionId);
+  const roleByNodeId = classifyStructureMarkRoles(ops, structuralContextPaths);
+  addMarks(ops, transform, suggestionId, roleByNodeId);
 
   return { handled: ops.size > 0, transform };
 }
@@ -239,6 +241,7 @@ function addMarks(
   ops: Map<string, Op>,
   tr: Transform,
   suggestionId: SuggestionId,
+  roleByNodeId: Map<string, StructureMarkRole>,
 ) {
   const perfAddMarks = performance.now();
   const { structure } = getSuggestionMarks(tr.doc.type.schema);
@@ -264,7 +267,11 @@ function addMarks(
       }
     }
 
-    tr.addNodeMark(pos, structure.create({ id: suggestionId, data: { op } }));
+    const role = roleByNodeId.get(nodeId) ?? "primary";
+    tr.addNodeMark(
+      pos,
+      structure.create({ id: suggestionId, data: { op, role } }),
+    );
 
     return true;
   });
@@ -300,6 +307,172 @@ function hasStructureAddMark(node: Node) {
     if (!guardStructureMarkAttrs(mark.attrs)) return false;
     return mark.attrs.data.op.op === "add";
   });
+}
+
+function classifyStructureMarkRoles(
+  ops: Map<string, Op>,
+  structuralContextPaths: StructuralContextPath[],
+) {
+  const roleByNodeId = new Map<string, StructureMarkRole>();
+  const primaryBoundaryMoveIds = new Set<string>();
+
+  for (const [nodeId, op] of ops) {
+    if (op.op === "add") {
+      roleByNodeId.set(nodeId, "primary");
+      continue;
+    }
+
+    if (changesStructuralContextDepth(op, structuralContextPaths)) {
+      primaryBoundaryMoveIds.add(nodeId);
+      roleByNodeId.set(nodeId, "primary");
+    }
+  }
+
+  const hasPrimaryBoundaryMove = primaryBoundaryMoveIds.size > 0;
+
+  for (const [nodeId, op] of ops) {
+    if (roleByNodeId.has(nodeId)) continue;
+
+    if (
+      op.op === "move" &&
+      hasPrimaryBoundaryMove &&
+      isSupportingWrapperMove(op, structuralContextPaths)
+    ) {
+      roleByNodeId.set(nodeId, "supporting");
+      continue;
+    }
+
+    roleByNodeId.set(nodeId, "primary");
+  }
+
+  return roleByNodeId;
+}
+
+function changesStructuralContextDepth(
+  op: MoveOp,
+  structuralContextPaths: StructuralContextPath[],
+) {
+  return (
+    getStructuralContextDepth(op.from, structuralContextPaths) !==
+    getStructuralContextDepth(op.to, structuralContextPaths)
+  );
+}
+
+function isSupportingWrapperMove(
+  op: MoveOp,
+  structuralContextPaths: StructuralContextPath[],
+) {
+  const fromDepth = getStructuralContextDepth(op.from, structuralContextPaths);
+  const toDepth = getStructuralContextDepth(op.to, structuralContextPaths);
+
+  if (fromDepth === 0 || fromDepth !== toDepth) return false;
+
+  const fromInnermostParent = getInnermostStructuralParent(
+    op.from,
+    structuralContextPaths,
+  );
+  const toInnermostParent = getInnermostStructuralParent(
+    op.to,
+    structuralContextPaths,
+  );
+
+  if (!fromInnermostParent || !toInnermostParent) return false;
+  if (fromInnermostParent.nodeId !== toInnermostParent.nodeId) return false;
+
+  return changesOuterStructuralWrapper(op, structuralContextPaths);
+}
+
+function getStructuralContextDepth(
+  chain: Parent[],
+  structuralContextPaths: StructuralContextPath[],
+) {
+  const topDownNodeTypes = getTopDownRealParents(chain).map(
+    (parent) => parent.nodeType,
+  );
+
+  return structuralContextPaths.reduce(
+    (depth, path) =>
+      depth + countContiguousPathOccurrences(topDownNodeTypes, path),
+    0,
+  );
+}
+
+function getInnermostStructuralParent(
+  chain: Parent[],
+  structuralContextPaths: StructuralContextPath[],
+) {
+  const topDownParents = getTopDownRealParents(chain);
+
+  for (let endIndex = topDownParents.length - 1; endIndex >= 0; endIndex--) {
+    for (const path of structuralContextPaths) {
+      const startIndex = endIndex - path.length + 1;
+      if (startIndex < 0) continue;
+
+      const matches = path.every(
+        (nodeType, pathIndex) =>
+          topDownParents[startIndex + pathIndex]?.nodeType === nodeType,
+      );
+
+      if (matches) return topDownParents[endIndex];
+    }
+  }
+
+  return null;
+}
+
+function changesOuterStructuralWrapper(
+  op: MoveOp,
+  structuralContextPaths: StructuralContextPath[],
+) {
+  const contextNodeTypes = getStructuralContextNodeTypes(
+    structuralContextPaths,
+  );
+  const fromParents = getTopDownRealParents(op.from);
+  const toParents = getTopDownRealParents(op.to);
+  const length = Math.min(fromParents.length, toParents.length);
+
+  for (let index = 0; index < length; index++) {
+    const fromParent = fromParents[index];
+    const toParent = toParents[index];
+    if (!fromParent || !toParent) continue;
+    if (fromParent.nodeId === toParent.nodeId) continue;
+
+    if (
+      contextNodeTypes.has(fromParent.nodeType) ||
+      contextNodeTypes.has(toParent.nodeType)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getTopDownRealParents(chain: Parent[]) {
+  return [...chain]
+    .reverse()
+    .filter((parent) => parent.nodeType !== DOC_NODE_ID);
+}
+
+function countContiguousPathOccurrences(
+  chainNodeTypes: string[],
+  structuralContextPath: StructuralContextPath,
+) {
+  let count = 0;
+
+  for (
+    let startIndex = 0;
+    startIndex <= chainNodeTypes.length - structuralContextPath.length;
+    startIndex++
+  ) {
+    const matches = structuralContextPath.every(
+      (nodeType, pathIndex) =>
+        chainNodeTypes[startIndex + pathIndex] === nodeType,
+    );
+    if (matches) count++;
+  }
+
+  return count;
 }
 
 function getOps(

--- a/src/features/wrapUnwrap/structureChangesPlugin.ts
+++ b/src/features/wrapUnwrap/structureChangesPlugin.ts
@@ -1,0 +1,489 @@
+import { type Schema, type Node } from "prosemirror-model";
+import {
+  type EditorState,
+  Plugin,
+  PluginKey,
+  type Transaction,
+} from "prosemirror-state";
+import { getSuggestionMarks } from "../../utils.js";
+import { generateNextNumberId, type SuggestionId } from "../../generateId.js";
+import { getNodeId } from "./getNodeId.js";
+import {
+  guardStructureMarkAttrs,
+  type MoveOp,
+  type Op,
+  type MaterializedPaths,
+  type Parent,
+  type StructuralContextPath,
+} from "./types.js";
+import { DOC_NODE_ID, STRUCTURE_CHANGES_ADD_MARKS } from "./constants.js";
+import { Transform } from "prosemirror-transform";
+import { isSuggestChangesEnabled, suggestChangesKey } from "../../plugin.js";
+import { buildMaterializedPaths } from "./buildMaterializedPaths.js";
+import { sameParentChain } from "./sameParentChain.js";
+
+const TRACE_ENABLED = false;
+function trace(...args: unknown[]) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!TRACE_ENABLED) return;
+  console.log("[structureChanges]", ...args);
+}
+
+export const structureChangesKey = new PluginKey(
+  "@handlewithcare/prosemirror-suggest-changes-structure-changes",
+);
+
+export type SuggestStructureChangesReason = "split-derived-add";
+
+export interface SuggestStructureChangesResult {
+  handled: boolean;
+  transform: Transform;
+  reason?: SuggestStructureChangesReason;
+}
+
+export function structureChangesPlugin(
+  generateId?: (schema: Schema, doc?: Node) => SuggestionId,
+  opts?: { experimental_trackStructures?: StructuralContextPath[] },
+) {
+  const structuralContextPaths = getRequiredStructuralContextPaths(
+    opts?.experimental_trackStructures,
+  );
+
+  return new Plugin({
+    key: structureChangesKey,
+    appendTransaction(transactions, _oldState, newState) {
+      if (transactions.some((tr) => !isEnabled(tr, newState))) {
+        console.warn(
+          "structureChangesPlugin",
+          "tracking changes is disabled, skipping structure changes plugin",
+          [...transactions],
+        );
+        return;
+      }
+
+      // do nothing if doc hasn't changed
+      const docChanged = transactions.some(
+        (transaction) => transaction.docChanged,
+      );
+      if (!docChanged) {
+        console.warn("structureChangesPlugin", "doc not changed, skipping", [
+          ...transactions,
+        ]);
+        return;
+      }
+
+      const firstTr = transactions[0];
+      const lastTr = transactions[transactions.length - 1];
+
+      const oldDoc = firstTr?.docs[0];
+      const newDoc = lastTr?.doc;
+
+      // do nothing if there isn't a pair of docs to compare
+      if (!oldDoc || !newDoc) {
+        console.warn(
+          "structureChangesPlugin",
+          "old or new doc is missing, skipping",
+          {
+            oldDoc,
+            newDoc,
+            transactions: [...transactions],
+          },
+        );
+        return;
+      }
+
+      let idsSettled = true as boolean;
+
+      newDoc.descendants((node, pos) => {
+        if (node.isText) return true;
+        const nodeId = getNodeId(node);
+        if (nodeId == null) {
+          console.warn(
+            "structureChangesPlugin",
+            "node",
+            node.type.name,
+            "at pos",
+            pos,
+            "is missing a unique id",
+            { id: node.attrs["id"] as unknown },
+          );
+          idsSettled = false;
+          return true;
+        }
+        return true;
+      });
+
+      oldDoc.descendants((node, pos) => {
+        if (node.isText) return true;
+        const nodeId = getNodeId(node);
+        if (nodeId == null) {
+          console.warn(
+            "structureChangesPlugin",
+            "node",
+            node.type.name,
+            "at pos",
+            pos,
+            "is missing a unique id",
+            { id: node.attrs["id"] as unknown },
+          );
+          idsSettled = false;
+          return true;
+        }
+        return true;
+      });
+
+      // do nothing if some nodes are missing unique ids - the diff is not possible then
+      if (!idsSettled) {
+        console.warn("structureChangesPlugin", "ids not settled, skipping", {
+          oldDoc,
+          newDoc,
+          transactions: [...transactions],
+        });
+        return;
+      }
+
+      trace("structureChangesPlugin", "appendTransaction", [...transactions]);
+
+      const { transform } = suggestStructureChanges(
+        oldDoc,
+        newDoc,
+        structuralContextPaths,
+        generateId,
+      );
+
+      const tr = newState.tr;
+      transform.steps.forEach((step) => {
+        tr.step(step);
+      });
+
+      if (!tr.steps.length) return;
+
+      tr.setMeta(structureChangesKey, STRUCTURE_CHANGES_ADD_MARKS);
+      return tr;
+    },
+  });
+}
+
+function isEnabled(tr: Transaction, editorState: EditorState) {
+  const ySyncMeta = (tr.getMeta("y-sync$") ?? {}) as {
+    isUndoRedoOperation?: boolean;
+    isChangeOrigin?: boolean;
+  };
+
+  const isEnabled =
+    isSuggestChangesEnabled(editorState) &&
+    !tr.getMeta("history$") &&
+    !tr.getMeta("collab$") &&
+    !ySyncMeta.isUndoRedoOperation &&
+    !ySyncMeta.isChangeOrigin &&
+    !("skip" in (tr.getMeta(suggestChangesKey) ?? {}));
+
+  return isEnabled;
+}
+
+export function suggestStructureChanges(
+  docBefore: Node,
+  docAfter: Node,
+  structuralContextPaths: StructuralContextPath[],
+  generateId?: (schema: Schema, doc?: Node) => SuggestionId,
+): SuggestStructureChangesResult {
+  const suggestionId = generateId
+    ? generateId(docBefore.type.schema, docBefore)
+    : generateNextNumberId(docBefore.type.schema, docBefore);
+
+  const pathsBefore = buildMaterializedPaths(docBefore);
+  const pathsAfter = buildMaterializedPaths(docAfter);
+
+  trace("suggestStructureChanges", "materialized paths", {
+    pathsBefore: Object.fromEntries(pathsBefore.entries()),
+    pathsAfter: Object.fromEntries(pathsAfter.entries()),
+  });
+
+  const { ops, reason } = getOps(
+    pathsBefore,
+    pathsAfter,
+    structuralContextPaths,
+  );
+  trace("suggestStructureChanges", "ops", {
+    ops: Object.fromEntries(ops.entries()),
+    reason,
+  });
+
+  const transform = new Transform(docAfter);
+
+  if (reason) {
+    return { handled: false, transform, reason };
+  }
+
+  addMarks(ops, transform, suggestionId);
+
+  return { handled: ops.size > 0, transform };
+}
+
+export function getRequiredStructuralContextPaths(
+  structuralContextPaths: StructuralContextPath[] | undefined,
+) {
+  if (!structuralContextPaths?.length) {
+    throw new Error(
+      "experimental_trackStructures must be provided when structure tracking is enabled",
+    );
+  }
+
+  return structuralContextPaths;
+}
+
+function addMarks(
+  ops: Map<string, Op>,
+  tr: Transform,
+  suggestionId: SuggestionId,
+) {
+  const perfAddMarks = performance.now();
+  const { structure } = getSuggestionMarks(tr.doc.type.schema);
+  tr.doc.descendants((node, pos) => {
+    if (node.isText) return true;
+
+    const nodeId = getNodeId(node);
+    if (nodeId == null) return true;
+
+    const op = ops.get(nodeId);
+    if (op == null) return true;
+
+    if (op.op === "move") {
+      if (hasStructureAddMark(node)) return true;
+
+      const inverseMoveMark = findInverseStructureMoveMark(node, op);
+      if (inverseMoveMark) {
+        tr.removeNodeMark(pos, inverseMoveMark);
+        return true;
+      }
+    }
+
+    tr.addNodeMark(pos, structure.create({ id: suggestionId, data: { op } }));
+
+    return true;
+  });
+  trace(
+    "perf",
+    "addMarks",
+    "took",
+    Number((performance.now() - perfAddMarks).toFixed(2)),
+    "ms",
+  );
+}
+
+function findInverseStructureMoveMark(node: Node, op: MoveOp) {
+  const { structure } = getSuggestionMarks(node.type.schema);
+  return node.marks.find((mark) => {
+    if (mark.type !== structure) return false;
+    if (!guardStructureMarkAttrs(mark.attrs)) return false;
+
+    const existingOp = mark.attrs.data.op;
+    if (existingOp.op !== "move") return false;
+
+    return (
+      sameParentChain(existingOp.from, op.to) &&
+      sameParentChain(existingOp.to, op.from)
+    );
+  });
+}
+
+function hasStructureAddMark(node: Node) {
+  const { structure } = getSuggestionMarks(node.type.schema);
+  return node.marks.some((mark) => {
+    if (mark.type !== structure) return false;
+    if (!guardStructureMarkAttrs(mark.attrs)) return false;
+    return mark.attrs.data.op.op === "add";
+  });
+}
+
+function getOps(
+  beforePaths: MaterializedPaths,
+  afterPaths: MaterializedPaths,
+  structuralContextPaths: StructuralContextPath[],
+): { ops: Map<string, Op>; reason?: SuggestStructureChangesReason } {
+  const ops = new Map<string, Op>();
+  const contextNodeTypes = getStructuralContextNodeTypes(
+    structuralContextPaths,
+  );
+
+  // first take care of nodes that exist in both
+  for (const [id, beforePath] of beforePaths) {
+    if (contextNodeTypes.has(beforePath.nodeType)) continue;
+
+    const afterPath = afterPaths.get(id);
+    // node was removed - do nothing
+    if (afterPath == null) continue;
+    if (contextNodeTypes.has(afterPath.nodeType)) continue;
+
+    const sameChain = sameParentChain(beforePath.chain, afterPath.chain);
+    // node did not move anywhere - do nothing
+    if (sameChain) continue;
+
+    const hasStructuralContext =
+      chainHasStructuralContext(beforePath.chain, structuralContextPaths) ||
+      chainHasStructuralContext(afterPath.chain, structuralContextPaths);
+    // node is outside configured structural contexts
+    if (!hasStructuralContext) continue;
+
+    const op: Op = { op: "move", from: beforePath.chain, to: afterPath.chain };
+    ops.set(id, op);
+  }
+
+  // now take care of nodes that exist only in afterPaths
+  // (we don't care about nodes that exist only in beforePaths - they were deleted)
+
+  for (const [id, afterPath] of afterPaths) {
+    if (contextNodeTypes.has(afterPath.nodeType)) continue;
+
+    // ignore nodes that also exist in beforePaths - they are already handled
+    if (beforePaths.has(id)) continue;
+
+    const hasStructuralContext = chainHasStructuralContext(
+      afterPath.chain,
+      structuralContextPaths,
+    );
+    // node is outside configured structural contexts
+    if (!hasStructuralContext) continue;
+
+    // detect block split - if detected, bail out, and let the main plugin handle it
+    if (isSplitDerivedAdd(id, beforePaths, afterPaths, contextNodeTypes)) {
+      return { ops: new Map(), reason: "split-derived-add" };
+    }
+
+    // node was added
+    const op: Op = { op: "add" };
+    ops.set(id, op);
+  }
+
+  return { ops };
+}
+
+function getStructuralContextNodeTypes(
+  structuralContextPaths: StructuralContextPath[],
+) {
+  return new Set(structuralContextPaths.flat());
+}
+
+function chainHasStructuralContext(
+  chain: Parent[],
+  structuralContextPaths: StructuralContextPath[],
+) {
+  const topDownChain = [...chain]
+    .reverse()
+    .filter((parent) => parent.nodeType !== DOC_NODE_ID)
+    .map((parent) => parent.nodeType);
+
+  return structuralContextPaths.some((path) =>
+    containsContiguousPath(topDownChain, path),
+  );
+}
+
+// does a chain like: nodeTypeA->nodeTypeB->nodeTypeC
+// end with a structural context path like nodeTypeB->nodeTypeC ?
+function containsContiguousPath(
+  chainNodeTypes: string[],
+  structuralContextPath: StructuralContextPath,
+) {
+  if (structuralContextPath.length > chainNodeTypes.length) return false;
+
+  let structuralPathPointer = structuralContextPath.length - 1;
+  let chainPointer = chainNodeTypes.length - 1;
+
+  while (structuralPathPointer >= 0) {
+    if (
+      structuralContextPath[structuralPathPointer] !==
+      chainNodeTypes[chainPointer]
+    ) {
+      return false;
+    }
+
+    structuralPathPointer--;
+    chainPointer--;
+  }
+
+  return true;
+}
+
+// detect block split - try to look at the node above, concatenate two text contents,
+// and see if it combines into a single node in the old document
+function isSplitDerivedAdd(
+  newNodeId: string,
+  beforePaths: MaterializedPaths,
+  afterPaths: MaterializedPaths,
+  contextNodeTypes: Set<string>,
+) {
+  const newNode = afterPaths.get(newNodeId)?.node;
+  if (!newNode || newNode.textContent === "") return false;
+
+  if (
+    matchesSplitDerivedPair(
+      newNodeId,
+      newNode.textContent,
+      beforePaths,
+      afterPaths,
+    )
+  ) {
+    return true;
+  }
+
+  const afterPath = afterPaths.get(newNodeId);
+  if (!afterPath) return false;
+
+  for (const parent of afterPath.chain) {
+    if (parent.nodeType === DOC_NODE_ID) continue;
+    if (!contextNodeTypes.has(parent.nodeType)) continue;
+
+    const parentNode = afterPaths.get(parent.nodeId)?.node;
+    if (!parentNode || parentNode.textContent === "") continue;
+
+    if (
+      matchesSplitDerivedPair(
+        parent.nodeId,
+        parentNode.textContent,
+        beforePaths,
+        afterPaths,
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function matchesSplitDerivedPair(
+  rightNodeId: string,
+  rightText: string,
+  beforePaths: MaterializedPaths,
+  afterPaths: MaterializedPaths,
+) {
+  const rightPath = afterPaths.get(rightNodeId);
+  const previousSiblingId = rightPath?.chain[0]?.childSiblingIds[0];
+  if (!previousSiblingId) return false;
+
+  const previousBefore = beforePaths.has(previousSiblingId)
+    ? beforePaths.get(previousSiblingId)?.node
+    : null;
+  const previousAfter = afterPaths.has(previousSiblingId)
+    ? afterPaths.get(previousSiblingId)?.node
+    : null;
+
+  if (!previousBefore || !previousAfter) return false;
+  if (hasStructureAddMarkInSubtree(previousBefore)) return false;
+
+  return previousBefore.textContent === previousAfter.textContent + rightText;
+}
+
+function hasStructureAddMarkInSubtree(node: Node) {
+  if (hasStructureAddMark(node)) return true;
+
+  let found = false;
+  node.descendants((descendant) => {
+    if (descendant.isText) return false;
+    if (!hasStructureAddMark(descendant)) return true;
+    found = true;
+    return false;
+  });
+
+  return found;
+}

--- a/src/features/wrapUnwrap/structureChangesPlugin.ts
+++ b/src/features/wrapUnwrap/structureChangesPlugin.ts
@@ -212,6 +212,9 @@ export function suggestStructureChanges(
   const transform = new Transform(docAfter);
 
   if (reason) {
+    // A reason is an intentional fallthrough, not an error. The Structure
+    // detector recognized a shape that should be handled by normal suggestion
+    // tracking.
     return { handled: false, transform, reason };
   }
 
@@ -249,6 +252,9 @@ function addMarks(
     if (op == null) return true;
 
     if (op.op === "move") {
+      // A provisional Structure add already means this node is not accepted yet.
+      // Moving it should not create a second review artifact until the add is
+      // accepted.
       if (hasStructureAddMark(node)) return true;
 
       const inverseMoveMark = findInverseStructureMoveMark(node, op);
@@ -413,6 +419,8 @@ function isSplitDerivedAdd(
   contextNodeTypes: Set<string>,
 ) {
   const newNode = afterPaths.get(newNodeId)?.node;
+  // Empty after-only nodes are not considered split-derived in whole-doc diff
+  // mode. Without a step-local proof of a split, keep them as Structure adds.
   if (!newNode || newNode.textContent === "") return false;
 
   if (

--- a/src/features/wrapUnwrap/types.ts
+++ b/src/features/wrapUnwrap/types.ts
@@ -1,0 +1,99 @@
+import { type Attrs, type Node } from "prosemirror-model";
+import { type SuggestionId } from "../../generateId.js";
+import { DOC_NODE_ID } from "./constants.js";
+
+interface NodeParent {
+  nodeId: string;
+  nodeType: string;
+  nodeAttrs: object;
+  nodeMarks: object[];
+  childSiblingIds: [string | null, string | null];
+  childIndex: number;
+}
+
+interface StructureMoveMarkAttrs {
+  id: SuggestionId;
+  data: { op: MoveOp };
+}
+
+interface StructureAddMarkAttrs {
+  id: SuggestionId;
+  data: { op: AddOp };
+}
+
+export type StructureMarkAttrs = StructureMoveMarkAttrs | StructureAddMarkAttrs;
+
+export type StructuralContextPath = readonly [string, ...string[]];
+
+export interface DocParent extends Omit<NodeParent, "nodeId"> {
+  nodeId: typeof DOC_NODE_ID;
+  nodeType: typeof DOC_NODE_ID;
+}
+
+export type Parent = NodeParent | DocParent;
+
+export interface MoveOp {
+  op: "move";
+  from: Parent[];
+  to: Parent[];
+}
+
+export interface AddOp {
+  op: "add";
+}
+
+export type Op = MoveOp | AddOp;
+
+export type MaterializedPaths = Map<
+  string,
+  { chain: Parent[]; nodeType: string; node: Node }
+>;
+
+export function guardDocParent(
+  parent: Parent | undefined,
+): parent is DocParent {
+  return (
+    parent != null &&
+    parent.nodeId === DOC_NODE_ID &&
+    parent.nodeType === DOC_NODE_ID
+  );
+}
+
+export function guardStructureMarkAttrs(
+  attrs: Attrs,
+): attrs is StructureMarkAttrs {
+  if (!("data" in attrs)) return false;
+
+  const data = attrs["data"] as unknown;
+  if (data === null || typeof data !== "object") return false;
+
+  if (!("op" in data)) return false;
+
+  return true;
+}
+
+export function guardStructureMoveMarkAttrs(
+  attrs: Attrs,
+): attrs is StructureMoveMarkAttrs {
+  return guardStructureMarkAttrs(attrs) && attrs.data.op.op === "move";
+}
+
+export function guardStructureAddMarkAttrs(
+  attrs: Attrs,
+): attrs is StructureAddMarkAttrs {
+  return guardStructureMarkAttrs(attrs) && attrs.data.op.op === "add";
+}
+
+export interface StructureMarkObject {
+  type: "structure";
+  attrs: StructureMarkAttrs;
+}
+
+export function guardStructureMarkObject(
+  mark: unknown,
+): mark is StructureMarkObject {
+  if (mark === null || typeof mark !== "object") return false;
+  if (!("type" in mark) || mark.type !== "structure") return false;
+  if (!("attrs" in mark)) return false;
+  return guardStructureMarkAttrs(mark.attrs as Attrs);
+}

--- a/src/features/wrapUnwrap/types.ts
+++ b/src/features/wrapUnwrap/types.ts
@@ -11,14 +11,26 @@ interface NodeParent {
   childIndex: number;
 }
 
+export type StructureMarkRole = "primary" | "supporting";
+
+interface StructureMoveMarkData {
+  op: MoveOp;
+  role?: StructureMarkRole;
+}
+
+interface StructureAddMarkData {
+  op: AddOp;
+  role?: StructureMarkRole;
+}
+
 interface StructureMoveMarkAttrs {
   id: SuggestionId;
-  data: { op: MoveOp };
+  data: StructureMoveMarkData;
 }
 
 interface StructureAddMarkAttrs {
   id: SuggestionId;
-  data: { op: AddOp };
+  data: StructureAddMarkData;
 }
 
 export type StructureMarkAttrs = StructureMoveMarkAttrs | StructureAddMarkAttrs;
@@ -70,6 +82,12 @@ export function guardStructureMarkAttrs(
   if (!("op" in data)) return false;
 
   return true;
+}
+
+export function getStructureMarkRole(
+  attrs: StructureMarkAttrs,
+): StructureMarkRole {
+  return attrs.data.role === "supporting" ? "supporting" : "primary";
 }
 
 export function guardStructureMoveMarkAttrs(

--- a/src/features/wrapUnwrap/uniqueNodeIdsPlugin.ts
+++ b/src/features/wrapUnwrap/uniqueNodeIdsPlugin.ts
@@ -1,0 +1,164 @@
+import { type Node } from "prosemirror-model";
+import { Plugin, PluginKey, type Transaction } from "prosemirror-state";
+import { getNodeId } from "./getNodeId.js";
+import { Transform } from "prosemirror-transform";
+
+// unique ids plugin
+// https://discuss.prosemirror.net/t/how-to-avoid-copying-attributes-to-new-paragraph/4568/2
+// (also checks and fix duplicates that inevitably appear)
+
+export const uniqueNodeIdsPluginKey = new PluginKey<{
+  completedInitialRun: boolean;
+}>("@handlewithcare/prosemirror-suggest-changes-unique-node-ids");
+
+export const UNIQUE_NODE_IDS_PLUGIN_META = "unique-node-ids-plugin";
+
+const TRACE_ENABLED = false;
+function trace(...args: unknown[]) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!TRACE_ENABLED) return;
+  console.log("[uniqueNodeIdsPlugin]", ...args);
+}
+
+export function uniqueNodeIdsPlugin({
+  attributeName,
+  generateID,
+}: {
+  attributeName: string;
+  generateID: () => string;
+}) {
+  return new Plugin<{ completedInitialRun: boolean }>({
+    key: uniqueNodeIdsPluginKey,
+    appendTransaction(transactions, oldState, newState) {
+      trace("appendTransaction");
+      const pluginState = uniqueNodeIdsPluginKey.getState(newState);
+
+      // do nothing if doc hasn't changed (but make sure it runs initially)
+      const docChanged = transactions.some(
+        (transaction) => transaction.docChanged,
+      );
+      if (!docChanged && pluginState?.completedInitialRun) {
+        trace("doc not changed, skipping", [...transactions]);
+        return;
+      }
+
+      trace("appendTransaction", [...transactions]);
+
+      const tr = newState.tr;
+
+      const transform = ensureUniqueNodeIds(
+        transactions as Transaction[],
+        oldState.doc,
+        newState.doc,
+        {
+          attributeName,
+          generateID,
+        },
+      );
+
+      transform.steps.forEach((step) => {
+        tr.step(step);
+      });
+
+      trace("tr steps", tr.steps);
+
+      if (!tr.steps.length) return;
+
+      tr.setMeta(uniqueNodeIdsPluginKey, UNIQUE_NODE_IDS_PLUGIN_META);
+      return tr;
+    },
+    state: {
+      init() {
+        return { completedInitialRun: false };
+      },
+      apply(tr, value) {
+        const meta = tr.getMeta(uniqueNodeIdsPluginKey) as string | undefined;
+        if (
+          meta === UNIQUE_NODE_IDS_PLUGIN_META &&
+          !value.completedInitialRun
+        ) {
+          return { completedInitialRun: true };
+        }
+        return value;
+      },
+    },
+  });
+}
+
+export function ensureUniqueNodeIds(
+  _transactions: Transaction[],
+  _oldDoc: Node,
+  newDoc: Node,
+  options: {
+    attributeName: string;
+    generateID: () => string;
+  },
+): Transform {
+  const tr = new Transform(newDoc);
+
+  const nodeIds = new Set<string>();
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (TRACE_ENABLED) console.groupCollapsed("ensureUniqueNodeIds");
+
+  tr.doc.descendants((node, pos) => {
+    if (node.isText) return false;
+
+    const nodeId = getNodeId(node);
+
+    // nodeId is set and is not duplicated
+    if (nodeId != null && !nodeIds.has(nodeId)) {
+      nodeIds.add(nodeId);
+      return true;
+    }
+
+    // nodeId is set and it is duplicated
+    if (nodeId != null && nodeIds.has(nodeId)) {
+      const id = options.generateID();
+      nodeIds.add(id);
+      tr.setNodeMarkup(
+        pos,
+        node.type,
+        {
+          ...node.attrs,
+          [options.attributeName]: id,
+        },
+        node.marks,
+      );
+      trace(
+        "fixed duplicate id",
+        id,
+        "for node",
+        node.type.name,
+        "at pos",
+        pos,
+        { was: nodeId, is: id },
+      );
+      return true;
+    }
+
+    // node id is not set
+    if (nodeId == null) {
+      const id = options.generateID();
+      nodeIds.add(id);
+      tr.setNodeMarkup(
+        pos,
+        node.type,
+        {
+          ...node.attrs,
+          [options.attributeName]: id,
+        },
+        node.marks,
+      );
+      trace("set unique id", id, "for node", node.type.name, "at pos", pos);
+      return true;
+    }
+
+    return true;
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (TRACE_ENABLED) console.groupEnd();
+
+  return tr;
+}

--- a/src/features/wrapUnwrap/uniqueNodeIdsPlugin.ts
+++ b/src/features/wrapUnwrap/uniqueNodeIdsPlugin.ts
@@ -33,7 +33,8 @@ export function uniqueNodeIdsPlugin({
       trace("appendTransaction");
       const pluginState = uniqueNodeIdsPluginKey.getState(newState);
 
-      // do nothing if doc hasn't changed (but make sure it runs initially)
+      // Structure tracking relies on stable node IDs even for the initial
+      // document. Run once without a doc change, then only rerun after edits.
       const docChanged = transactions.some(
         (transaction) => transaction.docChanged,
       );
@@ -106,13 +107,14 @@ export function ensureUniqueNodeIds(
 
     const nodeId = getNodeId(node);
 
-    // nodeId is set and is not duplicated
     if (nodeId != null && !nodeIds.has(nodeId)) {
       nodeIds.add(nodeId);
       return true;
     }
 
-    // nodeId is set and it is duplicated
+    // ProseMirror commands such as split can copy attrs onto new nodes. Duplicates
+    // must be rewritten immediately or structure diffing cannot tell which node
+    // moved and which node was newly materialized.
     if (nodeId != null && nodeIds.has(nodeId)) {
       const id = options.generateID();
       nodeIds.add(id);

--- a/src/generateId.ts
+++ b/src/generateId.ts
@@ -1,5 +1,7 @@
 import { type Node, type Schema } from "prosemirror-model";
 import { getSuggestionMarks } from "./utils.js";
+import { isJoinMark } from "./features/joinOnDelete/types.js";
+import { normalizeJoinNodesMetadata } from "./features/joinOnDelete/normalizeJoinNodesMetadata.js";
 
 export type SuggestionId = string | number;
 
@@ -14,19 +16,46 @@ export function parseSuggestionId(id: string): SuggestionId {
 }
 
 export function generateNextNumberId(schema: Schema, doc?: Node) {
-  const { deletion, insertion, modification } = getSuggestionMarks(schema);
+  const { deletion, insertion, modification, structure } =
+    getSuggestionMarks(schema);
   // Find the highest change id in the document so far,
   // and use that as the starting point for new changes
   let suggestionId = 0;
   doc?.descendants((node) => {
-    const mark = node.marks.find(
+    // find max suggestion id across all suggestion marks and across all suggestion marks that are serialized into metadata of the join marks
+    const marks = node.marks.filter(
       (mark) =>
         mark.type === insertion ||
         mark.type === deletion ||
-        mark.type === modification,
+        mark.type === modification ||
+        mark.type === structure,
     );
-    if (mark) {
-      suggestionId = Math.max(suggestionId, mark.attrs["id"] as number);
+
+    const markIds = marks.map((mark) => mark.attrs["id"] as number);
+
+    // collect suggestion ids of marks that are serialized into join marks metadata
+    const joinMarks = marks.filter((mark) => isJoinMark(mark));
+    const joinMetadataMarkIds: number[] = [];
+    joinMarks.forEach((mark) => {
+      const joinMetadata = normalizeJoinNodesMetadata(mark.attrs);
+      if (!joinMetadata) return;
+      joinMetadata.leftNodes.forEach((node) => {
+        node.marks.forEach((mark) => {
+          if (!mark.attrs["id"]) return;
+          joinMetadataMarkIds.push(mark.attrs["id"] as number);
+        });
+      });
+      joinMetadata.rightNodes.forEach((node) => {
+        node.marks.forEach((mark) => {
+          if (!mark.attrs["id"]) return;
+          joinMetadataMarkIds.push(mark.attrs["id"] as number);
+        });
+      });
+    });
+
+    const allMarkIds = [...markIds, ...joinMetadataMarkIds];
+    if (allMarkIds.length > 0) {
+      suggestionId = Math.max(suggestionId, ...allMarkIds);
       return false;
     }
     return true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export {
   ensureSelection as experimental_ensureSelection,
   ensureSelectionKey as experimental_ensureSelectionKey,
   isEnsureSelectionEnabled as experimental_isEnsureSelectionEnabled,
-} from "./ensureSelectionPlugin.js";
+} from "./features/ensureValidSelection/ensureSelectionPlugin.js";
 
 export { guardStructureMarkAttrs } from "./features/wrapUnwrap/types.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export {
   deletion,
   modification,
   hiddenDeletion,
+  structure,
 } from "./schema.js";
 
 export {
@@ -26,6 +27,7 @@ export {
 export {
   withSuggestChanges,
   transformToSuggestionTransaction,
+  suggestStructureChanges as experimental_suggestStructureChanges,
 } from "./withSuggestChanges.js";
 
 export {
@@ -33,3 +35,13 @@ export {
   ensureSelectionKey as experimental_ensureSelectionKey,
   isEnsureSelectionEnabled as experimental_isEnsureSelectionEnabled,
 } from "./ensureSelectionPlugin.js";
+
+export { guardStructureMarkAttrs } from "./features/wrapUnwrap/types.js";
+
+export type {
+  Op as StructureOp,
+  StructureMarkAttrs,
+  StructuralContextPath,
+} from "./features/wrapUnwrap/types.js";
+
+export { wrappingInputRule as experimental_wrappingInputRule } from "./wrappingInputRule.js";

--- a/src/listInputRules.ts
+++ b/src/listInputRules.ts
@@ -1,0 +1,23 @@
+import { type NodeType } from "prosemirror-model";
+import { wrappingInputRule } from "./wrappingInputRule.js";
+import { ZWSP } from "./constants.js";
+
+export function listInputRules(
+  bulletListNodeType: NodeType,
+  orderedListNodeType: NodeType,
+) {
+  const bulletListInputRule = wrappingInputRule(
+    // ^ string start, [${ZWSP}\\s]* zero or more ZWSP or whitespace, ([-+*]) one of -+* , \\s one whitespace, $ end of string
+    // "u" flag treats \u as unicode code points instead of literal "u"
+    new RegExp(`^[${ZWSP}\\s]*([-+*])\\s$`, "u"),
+    bulletListNodeType,
+  );
+  // ^ string start, [${ZWSP}\\s]* zero or more ZWSP or whitespace, ([0-9]+\\.) digit followed by dot, \\s one whitespace, $ end of string
+  // "u" flag treats \u as unicode code points instead of literal "u"
+  const orderedListInputRule = wrappingInputRule(
+    new RegExp(`^[${ZWSP}\\s]*([0-9]+\\.)\\s$`, "u"),
+    orderedListNodeType,
+  );
+
+  return [bulletListInputRule, orderedListInputRule];
+}

--- a/src/rebaseStep.ts
+++ b/src/rebaseStep.ts
@@ -1,0 +1,25 @@
+import { type Step } from "prosemirror-transform";
+
+/**
+ * Rebase a step onto a new lineage of steps
+ *
+ * @param step The step to rebase
+ * @param back The old steps to undo, in the order they were originally applied
+ * @param forth The new steps to map through
+ */
+export function rebaseStep(step: Step, back: Step[], forth: Step[]) {
+  const reset = back
+    .slice()
+    .reverse()
+    .reduce<Step | null>(
+      (acc, step) => acc?.map(step.getMap().invert()) ?? null,
+      step,
+    );
+
+  const rebased = forth.reduce(
+    (acc, step) => acc?.map(step.getMap()) ?? null,
+    reset,
+  );
+
+  return rebased;
+}

--- a/src/replaceStep.ts
+++ b/src/replaceStep.ts
@@ -4,7 +4,7 @@ import {
   TextSelection,
   type Transaction,
 } from "prosemirror-state";
-import { type Step, type ReplaceStep } from "prosemirror-transform";
+import { type ReplaceStep, type Step } from "prosemirror-transform";
 
 import { findSuggestionMarkEnd } from "./findSuggestionMarkEnd.js";
 import { rebasePos } from "./rebasePos.js";
@@ -18,6 +18,7 @@ import {
   removeZWSPDeletions,
 } from "./features/joinOnDelete/index.js";
 import { adjustForStartToStartTextblockDeletion } from "./features/startToStartTextblockDeletion/index.js";
+// import { rebaseStep } from "./rebaseStep.js";
 
 /**
  * Transform a replace step into its equivalent tracked steps.

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -142,6 +142,38 @@ export const modification: MarkSpec = {
   ],
 };
 
+export const structure: MarkSpec = {
+  inclusive: false,
+  excludes: "deletion insertion modification",
+  attrs: {
+    id: { validate: suggestionIdValidate },
+    data: { default: null },
+  },
+  toDOM(mark) {
+    return [
+      "div",
+      {
+        "data-type": "structure",
+        "data-id": JSON.stringify(mark.attrs["id"]),
+        "data-data": JSON.stringify(mark.attrs["data"]),
+      },
+      0,
+    ];
+  },
+  parseDOM: [
+    {
+      tag: "div[data-type='structure']",
+      getAttrs(node) {
+        if (!node.dataset["id"]) return false;
+        return {
+          id: JSON.parse(node.dataset["id"]) as SuggestionId,
+          data: JSON.parse(node.dataset["data"] ?? "null") as object | null,
+        };
+      },
+    },
+  ],
+};
+
 /**
  * Add the deletion, insertion, and modification marks to
  * the provided MarkSpec map.
@@ -149,12 +181,16 @@ export const modification: MarkSpec = {
 export function addSuggestionMarks<Marks extends string>(
   marks: Record<Marks, MarkSpec>,
   opts?: { experimental_deletions?: "hidden" | "visible" },
-): Record<Marks | "deletion" | "insertion" | "modification", MarkSpec> {
+): Record<
+  Marks | "deletion" | "insertion" | "modification" | "structure",
+  MarkSpec
+> {
   return {
     ...marks,
     deletion:
       opts?.experimental_deletions === "hidden" ? hiddenDeletion : deletion,
     insertion,
     modification,
+    structure,
   };
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -142,6 +142,12 @@ export const modification: MarkSpec = {
   ],
 };
 
+function getStructureDomRole(data: unknown) {
+  if (data === null || typeof data !== "object") return "primary";
+  if (!("role" in data)) return "primary";
+  return data.role === "supporting" ? "supporting" : "primary";
+}
+
 export const structure: MarkSpec = {
   inclusive: false,
   excludes: "deletion insertion modification",
@@ -150,12 +156,14 @@ export const structure: MarkSpec = {
     data: { default: null },
   },
   toDOM(mark) {
+    const data = mark.attrs["data"] as unknown;
     return [
       "div",
       {
         "data-type": "structure",
+        "data-role": getStructureDomRole(data),
         "data-id": JSON.stringify(mark.attrs["id"]),
-        "data-data": JSON.stringify(mark.attrs["data"]),
+        "data-data": JSON.stringify(data),
       },
       0,
     ];

--- a/src/testing/e2eTestSchema.ts
+++ b/src/testing/e2eTestSchema.ts
@@ -1,0 +1,58 @@
+import { Schema } from "prosemirror-model";
+import { bulletList, listItem, orderedList } from "prosemirror-schema-list";
+import { addSuggestionMarks } from "../schema.js";
+import { marks, nodes as schemaNodes } from "prosemirror-schema-basic";
+import { addIdAttr } from "../features/wrapUnwrap/addIdAttr.js";
+
+export function createSchema(
+  deletionMarksVisibility: "hidden" | "visible" = "visible",
+) {
+  const nodes = { ...schemaNodes };
+  for (const [key, nodeSpec] of Object.entries(nodes)) {
+    nodes[key as keyof typeof nodes] = addIdAttr(nodeSpec);
+  }
+
+  const listNodes = { orderedList, bulletList, listItem };
+  for (const [key, nodeSpec] of Object.entries(listNodes)) {
+    listNodes[key as keyof typeof listNodes] = addIdAttr(nodeSpec);
+  }
+
+  // Create schema with suggestion marks and list support
+  const schema = new Schema({
+    nodes: {
+      ...nodes,
+      doc: {
+        ...nodes.doc,
+        marks: "insertion deletion modification structure",
+      },
+      blockquote: {
+        ...nodes.blockquote,
+        group: "block",
+        marks: "insertion deletion modification structure",
+      },
+      orderedList: {
+        ...listNodes.orderedList,
+        group: "block",
+        content: "listItem+",
+        marks: "insertion deletion modification structure",
+      },
+      bulletList: {
+        ...listNodes.bulletList,
+        group: "block",
+        content: "listItem+",
+        marks: "insertion deletion modification structure",
+      },
+      listItem: {
+        ...listNodes.listItem,
+        content: "paragraph block*",
+        marks: "insertion deletion modification structure",
+      },
+      hardBreak: { ...nodes.hard_break },
+    },
+    marks: addSuggestionMarks(marks, {
+      experimental_deletions: deletionMarksVisibility,
+    }),
+  });
+
+  return schema;
+}

--- a/src/testing/testBuilders.ts
+++ b/src/testing/testBuilders.ts
@@ -4,22 +4,49 @@ import {
   type NodeBuilder,
   builders,
 } from "prosemirror-test-builder";
-import { nodes, marks } from "prosemirror-schema-basic";
+import { nodes as schemaNodes, marks } from "prosemirror-schema-basic";
 import { bulletList, listItem, orderedList } from "prosemirror-schema-list";
 import { addSuggestionMarks } from "../schema.js";
 import { difficulty } from "./difficultyMark.js";
+// import { addIdAttr } from "../features/wrapUnwrapV2/addIdAttr.js";
 
-const schema = new Schema({
+const nodes = { ...schemaNodes };
+// unit tests will fail because nodes will have an attribute id: null that is not expected
+// so we don't add id attribute to nodes for now for unit tests
+// it's probably not even necessary, or maybe two separate vitest projects are needed
+// for (const [key, nodeSpec] of Object.entries(nodes)) {
+//   nodes[key as keyof typeof nodes] = addIdAttr(nodeSpec, key);
+// }
+
+export const schema = new Schema({
   nodes: {
     ...nodes,
     image: { ...nodes.image, group: "block", inline: false },
-    doc: { ...nodes.doc, marks: "difficulty insertion deletion modification" },
-    orderedList: { ...orderedList, group: "block", content: "listItem+" },
-    bulletList: { ...bulletList, group: "block", content: "listItem+" },
+    doc: {
+      ...nodes.doc,
+      marks: "difficulty insertion deletion modification structure",
+    },
+    blockquote: {
+      ...nodes.blockquote,
+      group: "block",
+      marks: "difficulty insertion deletion modification structure",
+    },
+    orderedList: {
+      ...orderedList,
+      group: "block",
+      content: "listItem+",
+      marks: "difficulty insertion deletion modification structure",
+    },
+    bulletList: {
+      ...bulletList,
+      group: "block",
+      content: "listItem+",
+      marks: "difficulty insertion deletion modification structure",
+    },
     listItem: {
       ...listItem,
-      content: "block+",
-      marks: "insertion deletion modification",
+      content: "paragraph block*",
+      marks: "difficulty insertion deletion modification structure",
     },
   },
   marks: { ...addSuggestionMarks(marks), difficulty },

--- a/src/transformToSuggestionTransaction.ts
+++ b/src/transformToSuggestionTransaction.ts
@@ -1,0 +1,198 @@
+import { type Node, type Schema } from "prosemirror-model";
+import { type EditorState, type Transaction } from "prosemirror-state";
+import {
+  AddMarkStep,
+  AddNodeMarkStep,
+  AttrStep,
+  Mapping,
+  RemoveMarkStep,
+  RemoveNodeMarkStep,
+  ReplaceAroundStep,
+  ReplaceStep,
+  type Step,
+} from "prosemirror-transform";
+import { trackAddMarkStep } from "./addMarkStep.js";
+import { trackAddNodeMarkStep } from "./addNodeMarkStep.js";
+import { trackAttrStep } from "./attrStep.js";
+import { generateNextNumberId, type SuggestionId } from "./generateId.js";
+import { suggestRemoveMarkStep } from "./removeMarkStep.js";
+import { suggestRemoveNodeMarkStep } from "./removeNodeMarkStep.js";
+import { suggestReplaceAroundStep } from "./replaceAroundStep.js";
+import { suggestReplaceStep } from "./replaceStep.js";
+import { getSuggestionMarks } from "./utils.js";
+
+type StepHandler<S extends Step> = (
+  trackedTransaction: Transaction,
+  state: EditorState,
+  doc: Node,
+  step: S,
+  prevSteps: Step[],
+  suggestionId: SuggestionId,
+) => boolean;
+
+function getStepHandler<S extends Step>(step: S): StepHandler<S> {
+  if (step instanceof ReplaceStep) {
+    return suggestReplaceStep as unknown as StepHandler<S>;
+  }
+  if (step instanceof ReplaceAroundStep) {
+    return suggestReplaceAroundStep as unknown as StepHandler<S>;
+  }
+  if (step instanceof AddMarkStep) {
+    return trackAddMarkStep as unknown as StepHandler<S>;
+  }
+  if (step instanceof RemoveMarkStep) {
+    return suggestRemoveMarkStep as unknown as StepHandler<S>;
+  }
+  if (step instanceof AddNodeMarkStep) {
+    return trackAddNodeMarkStep as unknown as StepHandler<S>;
+  }
+  if (step instanceof RemoveNodeMarkStep) {
+    return suggestRemoveNodeMarkStep as unknown as StepHandler<S>;
+  }
+  if (step instanceof AttrStep) {
+    return trackAttrStep as unknown as StepHandler<S>;
+  }
+
+  // Default handler — simply rebase the step onto the
+  // tracked transaction and apply it.
+  return (
+    trackedTransaction: Transaction,
+    _state: EditorState,
+    _doc: Node,
+    step: S,
+    prevSteps: Step[],
+  ) => {
+    const reset = prevSteps
+      .slice()
+      .reverse()
+      .reduce<Step | null>(
+        (acc, step) => acc?.map(step.getMap().invert()) ?? null,
+        step,
+      );
+
+    const rebased = trackedTransaction.steps.reduce(
+      (acc, step) => acc?.map(step.getMap()) ?? null,
+      reset,
+    );
+
+    if (rebased) {
+      trackedTransaction.step(rebased);
+    }
+    return false;
+  };
+}
+
+interface PreserveTransactionDataOptions {
+  selection?: "mapFromOriginalTransaction" | "currentDocument" | false;
+  preserveScroll?: boolean;
+  preserveStoredMarks?: boolean;
+  preserveMeta?: boolean;
+}
+
+export function preserveTransactionData(
+  transaction: Transaction,
+  originalTransaction: Transaction,
+  options: PreserveTransactionDataOptions = {},
+) {
+  const {
+    selection = "mapFromOriginalTransaction",
+    preserveScroll = true,
+    preserveStoredMarks = true,
+    preserveMeta = true,
+  } = options;
+
+  if (
+    selection &&
+    originalTransaction.selectionSet &&
+    !transaction.selectionSet
+  ) {
+    if (selection === "currentDocument") {
+      transaction.setSelection(
+        originalTransaction.selection.map(transaction.doc, new Mapping()),
+      );
+    } else {
+      const originalBaseDoc = originalTransaction.docs[0];
+      const base = originalBaseDoc
+        ? originalTransaction.selection.map(
+            originalBaseDoc,
+            originalTransaction.mapping.invert(),
+          )
+        : originalTransaction.selection;
+
+      transaction.setSelection(base.map(transaction.doc, transaction.mapping));
+    }
+  }
+
+  if (preserveScroll && originalTransaction.scrolledIntoView) {
+    transaction.scrollIntoView();
+  }
+
+  if (preserveStoredMarks && originalTransaction.storedMarksSet) {
+    transaction.setStoredMarks(originalTransaction.storedMarks);
+  }
+
+  if (preserveMeta) {
+    // @ts-expect-error Preserve original transaction meta exactly as-is
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    transaction.meta = originalTransaction.meta;
+  }
+}
+
+/**
+ * Given a standard transaction from ProseMirror, produce
+ * a new transaction that tracks the changes from the original,
+ * rather than applying them.
+ *
+ * For each type of step, we implement custom behavior to prevent
+ * deletions from being removed from the document, instead adding
+ * deletion marks, and ensuring that all insertions have insertion
+ * marks.
+ */
+export function transformToSuggestionTransaction(
+  originalTransaction: Transaction,
+  state: EditorState,
+  generateId?: (schema: Schema, doc?: Node) => SuggestionId,
+) {
+  getSuggestionMarks(state.schema);
+
+  let suggestionId = generateId
+    ? generateId(state.schema, originalTransaction.docs[0])
+    : generateNextNumberId(state.schema, originalTransaction.docs[0]);
+  // Create a new transaction from scratch. The original transaction
+  // is going to be dropped in favor of this one.
+  const trackedTransaction = state.tr;
+
+  for (let i = 0; i < originalTransaction.steps.length; i++) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const step = originalTransaction.steps[i]!;
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const doc = originalTransaction.docs[i]!;
+
+    const stepTracker = getStepHandler(step);
+    if (
+      stepTracker(
+        trackedTransaction,
+        state,
+        doc,
+        step,
+        originalTransaction.steps.slice(0, i),
+        suggestionId,
+      ) &&
+      i < originalTransaction.steps.length - 1
+    ) {
+      // If the suggestionId was used by one of the step handlers,
+      // increment it so that it's not reused.
+      if (generateId) {
+        suggestionId = generateId(state.schema, trackedTransaction.doc);
+      } else if (typeof suggestionId === "number") {
+        suggestionId = suggestionId + 1;
+      }
+    }
+    continue;
+  }
+
+  preserveTransactionData(trackedTransaction, originalTransaction);
+
+  return trackedTransaction;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ export interface SuggestionMarks {
   insertion: MarkType;
   deletion: MarkType;
   modification: MarkType;
+  structure: MarkType;
 }
 
 /**
@@ -11,7 +12,7 @@ export interface SuggestionMarks {
  * Throws an error if any of the required marks are not found.
  */
 export function getSuggestionMarks(schema: Schema): SuggestionMarks {
-  const { insertion, deletion, modification } = schema.marks;
+  const { insertion, deletion, modification, structure } = schema.marks;
 
   if (!insertion) {
     throw new Error(
@@ -31,5 +32,11 @@ export function getSuggestionMarks(schema: Schema): SuggestionMarks {
     );
   }
 
-  return { insertion, deletion, modification };
+  if (!structure) {
+    throw new Error(
+      "Failed to find structure mark in schema. Did you forget to add it?",
+    );
+  }
+
+  return { insertion, deletion, modification, structure };
 }

--- a/src/withSuggestChanges.ts
+++ b/src/withSuggestChanges.ts
@@ -1,174 +1,27 @@
-import { type Schema, type Node } from "prosemirror-model";
-import { type EditorState, type Transaction } from "prosemirror-state";
-import {
-  AddMarkStep,
-  AddNodeMarkStep,
-  AttrStep,
-  RemoveMarkStep,
-  RemoveNodeMarkStep,
-  ReplaceAroundStep,
-  ReplaceStep,
-  type Step,
-} from "prosemirror-transform";
-
-import { trackAddMarkStep } from "./addMarkStep.js";
-import { trackAddNodeMarkStep } from "./addNodeMarkStep.js";
-import { trackAttrStep } from "./attrStep.js";
-import { suggestRemoveMarkStep } from "./removeMarkStep.js";
-import { suggestRemoveNodeMarkStep } from "./removeNodeMarkStep.js";
-import { suggestReplaceAroundStep } from "./replaceAroundStep.js";
-import { suggestReplaceStep } from "./replaceStep.js";
+import { type Node, type Schema } from "prosemirror-model";
+import { type Transaction } from "prosemirror-state";
+import { type Transform } from "prosemirror-transform";
 import { type EditorView } from "prosemirror-view";
 import { isSuggestChangesEnabled, suggestChangesKey } from "./plugin.js";
-import { generateNextNumberId, type SuggestionId } from "./generateId.js";
-import { getSuggestionMarks } from "./utils.js";
+import { type SuggestionId } from "./generateId.js";
 import { prependDeletionsWithZWSP } from "./prependDeletionsWithZWSP.js";
+import {
+  getRequiredStructuralContextPaths,
+  suggestStructureChanges,
+  type SuggestStructureChangesResult,
+} from "./features/wrapUnwrap/structureChangesPlugin.js";
+import { type StructuralContextPath } from "./features/wrapUnwrap/types.js";
+import { handleSpecialTransactionShape } from "./features/transactionShaping/index.js";
+import { transformToSuggestionTransaction } from "./transformToSuggestionTransaction.js";
 
-type StepHandler<S extends Step> = (
-  trackedTransaction: Transaction,
-  state: EditorState,
-  doc: Node,
-  step: S,
-  prevSteps: Step[],
-  suggestionId: SuggestionId,
-) => boolean;
+export { transformToSuggestionTransaction } from "./transformToSuggestionTransaction.js";
+export { suggestStructureChanges } from "./features/wrapUnwrap/structureChangesPlugin.js";
 
-function getStepHandler<S extends Step>(step: S): StepHandler<S> {
-  if (step instanceof ReplaceStep) {
-    return suggestReplaceStep as unknown as StepHandler<S>;
-  }
-  if (step instanceof ReplaceAroundStep) {
-    return suggestReplaceAroundStep as unknown as StepHandler<S>;
-  }
-  if (step instanceof AddMarkStep) {
-    return trackAddMarkStep as unknown as StepHandler<S>;
-  }
-  if (step instanceof RemoveMarkStep) {
-    return suggestRemoveMarkStep as unknown as StepHandler<S>;
-  }
-  if (step instanceof AddNodeMarkStep) {
-    return trackAddNodeMarkStep as unknown as StepHandler<S>;
-  }
-  if (step instanceof RemoveNodeMarkStep) {
-    return suggestRemoveNodeMarkStep as unknown as StepHandler<S>;
-  }
-  if (step instanceof AttrStep) {
-    return trackAttrStep as unknown as StepHandler<S>;
-  }
-
-  // Default handler — simply rebase the step onto the
-  // tracked transaction and apply it.
-  return (
-    trackedTransaction: Transaction,
-    _state: EditorState,
-    _doc: Node,
-    step: S,
-    prevSteps: Step[],
-  ) => {
-    const reset = prevSteps
-      .slice()
-      .reverse()
-      .reduce<Step | null>(
-        (acc, step) => acc?.map(step.getMap().invert()) ?? null,
-        step,
-      );
-
-    const rebased = trackedTransaction.steps.reduce(
-      (acc, step) => acc?.map(step.getMap()) ?? null,
-      reset,
-    );
-
-    if (rebased) {
-      trackedTransaction.step(rebased);
-    }
-    return false;
-  };
-}
-
-/**
- * Given a standard transaction from ProseMirror, produce
- * a new transaction that tracks the changes from the original,
- * rather than applying them.
- *
- * For each type of step, we implement custom behavior to prevent
- * deletions from being removed from the document, instead adding
- * deletion marks, and ensuring that all insertions have insertion
- * marks.
- */
-export function transformToSuggestionTransaction(
-  originalTransaction: Transaction,
-  state: EditorState,
-  generateId?: (schema: Schema, doc?: Node) => SuggestionId,
-) {
-  getSuggestionMarks(state.schema);
-
-  let suggestionId = generateId
-    ? generateId(state.schema, originalTransaction.docs[0])
-    : generateNextNumberId(state.schema, originalTransaction.docs[0]);
-  // Create a new transaction from scratch. The original transaction
-  // is going to be dropped in favor of this one.
-  const trackedTransaction = state.tr;
-
-  for (let i = 0; i < originalTransaction.steps.length; i++) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const step = originalTransaction.steps[i]!;
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const doc = originalTransaction.docs[i]!;
-
-    const stepTracker = getStepHandler(step);
-    if (
-      stepTracker(
-        trackedTransaction,
-        state,
-        doc,
-        step,
-        originalTransaction.steps.slice(0, i),
-        suggestionId,
-      ) &&
-      i < originalTransaction.steps.length - 1
-    ) {
-      // If the suggestionId was used by one of the step handlers,
-      // increment it so that it's not reused.
-      if (generateId) {
-        suggestionId = generateId(state.schema, trackedTransaction.doc);
-      } else if (typeof suggestionId === "number") {
-        suggestionId = suggestionId + 1;
-      }
-    }
-    continue;
-  }
-
-  if (originalTransaction.selectionSet && !trackedTransaction.selectionSet) {
-    // Map the original selection backwards through the original transaction,
-    // and then forwards through the new one.
-
-    const originalBaseDoc = originalTransaction.docs[0];
-    const base = originalBaseDoc
-      ? originalTransaction.selection.map(
-          originalBaseDoc,
-          originalTransaction.mapping.invert(),
-        )
-      : originalTransaction.selection;
-
-    trackedTransaction.setSelection(
-      base.map(trackedTransaction.doc, trackedTransaction.mapping),
-    );
-  }
-
-  if (originalTransaction.scrolledIntoView) {
-    trackedTransaction.scrollIntoView();
-  }
-
-  if (originalTransaction.storedMarksSet) {
-    trackedTransaction.setStoredMarks(originalTransaction.storedMarks);
-  }
-
-  // @ts-expect-error Preserve original transaction meta exactly as-is
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  trackedTransaction.meta = originalTransaction.meta;
-
-  return trackedTransaction;
+const TRACE_ENABLED = false;
+function trace(...args: unknown[]) {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!TRACE_ENABLED) return;
+  console.log("[withSuggestChanges]", ...args);
 }
 
 /**
@@ -185,6 +38,15 @@ export function transformToSuggestionTransaction(
 export function withSuggestChanges(
   dispatchTransaction?: EditorView["dispatch"],
   generateId?: (schema: Schema, doc?: Node) => SuggestionId,
+  opts?: {
+    experimental_trackStructureChanges?: boolean;
+    experimental_trackStructures?: StructuralContextPath[];
+    experimental_ensureUniqueNodeIds?: (
+      transactions: Transaction[],
+      oldDoc: Node,
+      newDoc: Node,
+    ) => Transform;
+  },
 ): EditorView["dispatch"] {
   const dispatch =
     dispatchTransaction ??
@@ -198,15 +60,119 @@ export function withSuggestChanges(
       isChangeOrigin?: boolean;
     };
 
-    const transaction =
+    const isEnabled =
       isSuggestChangesEnabled(this.state) &&
       !tr.getMeta("history$") &&
       !tr.getMeta("collab$") &&
       !ySyncMeta.isUndoRedoOperation &&
       !ySyncMeta.isChangeOrigin &&
-      !("skip" in (tr.getMeta(suggestChangesKey) ?? {}))
-        ? transformToSuggestionTransaction(tr, this.state, generateId)
-        : tr;
+      !("skip" in (tr.getMeta(suggestChangesKey) ?? {}));
+
+    let transaction = tr;
+
+    if (isEnabled) {
+      let structureChangesResult: SuggestStructureChangesResult | null = null;
+      const docBefore = transaction.docs[0];
+
+      const structuralContextPaths = opts?.experimental_trackStructureChanges
+        ? getRequiredStructuralContextPaths(opts.experimental_trackStructures)
+        : null;
+      const ensureUniqueNodeIds = opts?.experimental_ensureUniqueNodeIds;
+      const shapedTransaction = transaction.docChanged
+        ? handleSpecialTransactionShape({
+            transaction,
+            state: this.state,
+            generateId,
+            structuralContextPaths,
+            ensureUniqueNodeIds,
+          })
+        : null;
+
+      if (
+        !shapedTransaction &&
+        transaction.docChanged &&
+        docBefore &&
+        structuralContextPaths &&
+        typeof ensureUniqueNodeIds === "function"
+      ) {
+        trace("trying to track structure changes first...");
+        // after a transaction, some nodes may not yet have unique ids (they were just added, and the unique id plugin has not yet run)
+        // this hook allows to "post-process" the transaction and add the missing ids
+        // basically it allows to run the core logic of the unique ids plugin earlier
+        const perfUid = performance.now();
+        const uniqueNodeIdsTransform = ensureUniqueNodeIds(
+          [transaction],
+          docBefore,
+          transaction.doc,
+        );
+        trace(
+          "perf",
+          "structure",
+          "ensureUniqueNodsIds took",
+          Number((performance.now() - perfUid).toFixed(2)),
+          "ms",
+        );
+        const docAfter = uniqueNodeIdsTransform.doc;
+        trace("unique node ids set", docAfter);
+
+        // try running structure changes first
+        // if handled, then ignore the main plugin
+        // otherwise use the main plugin
+        const perfStructure = performance.now();
+        structureChangesResult = suggestStructureChanges(
+          docBefore,
+          docAfter,
+          structuralContextPaths,
+          generateId,
+        );
+        trace(
+          "perf",
+          "structure",
+          "suggestStructureChanges took",
+          Number((performance.now() - perfStructure).toFixed(2)),
+          "ms",
+        );
+        trace(
+          "structure changes transform completed",
+          structureChangesResult.transform,
+        );
+        if (structureChangesResult.handled) {
+          uniqueNodeIdsTransform.steps.forEach((step) => {
+            transaction.step(step);
+          });
+          structureChangesResult.transform.steps.forEach((step) => {
+            transaction.step(step);
+          });
+          trace(
+            "applied unique id transform and structure changes transform to the transaction",
+            transaction,
+          );
+        }
+      }
+
+      if (shapedTransaction) {
+        transaction = shapedTransaction;
+      } else if (
+        transaction.docChanged &&
+        structureChangesResult?.handled !== true
+      ) {
+        trace("running the main suggestions plugin...");
+        const perfSuggestions = performance.now();
+        transaction = transformToSuggestionTransaction(
+          tr,
+          this.state,
+          generateId,
+        );
+        trace(
+          "perf",
+          "suggestions",
+          "transformToSuggestionTransaction took",
+          Number((performance.now() - perfSuggestions).toFixed(2)),
+          "ms",
+        );
+        trace("main suggestions plugin completed", transaction);
+      }
+    }
 
     if (transaction.docChanged) {
       prependDeletionsWithZWSP(transaction);

--- a/src/withSuggestChanges.ts
+++ b/src/withSuggestChanges.ts
@@ -78,6 +78,10 @@ export function withSuggestChanges(
         ? getRequiredStructuralContextPaths(opts.experimental_trackStructures)
         : null;
       const ensureUniqueNodeIds = opts?.experimental_ensureUniqueNodeIds;
+      // Some editor commands emit compound transactions whose final doc diff looks
+      // structural, but whose user-visible edit needs normal suggestion tracking or
+      // a split structure/main route. Detect those before Structure tracking gets
+      // first claim on the transaction.
       const shapedTransaction = transaction.docChanged
         ? handleSpecialTransactionShape({
             transaction,
@@ -137,6 +141,9 @@ export function withSuggestChanges(
           structureChangesResult.transform,
         );
         if (structureChangesResult.handled) {
+          // Structure tracking is exclusive: once it handles a transaction, the
+          // main suggestion transformer will not run. Split-like false positives
+          // must bail out before this branch.
           uniqueNodeIdsTransform.steps.forEach((step) => {
             transaction.step(step);
           });

--- a/src/wrappingInputRule.ts
+++ b/src/wrappingInputRule.ts
@@ -1,0 +1,71 @@
+import { InputRule } from "prosemirror-inputrules";
+import { type Node } from "prosemirror-model";
+
+// this is a copy of wrappingInputRule from https://code.haverbeke.berlin/prosemirror/prosemirror-inputrules/src/tag/1.5.1/src/rulebuilders.ts#L20
+// but it tries to preserve ZWSPs instead of clearing the node completely
+// because otherwise it breaks paired ZWSP insertion marks (like when a block node is split)
+
+/// Build an input rule for automatically wrapping a textblock when a
+/// given string is typed. The `regexp` argument is
+/// directly passed through to the `InputRule` constructor. You'll
+/// probably want the regexp to start with `^`, so that the pattern can
+/// only occur at the start of a textblock.
+///
+/// `nodeType` is the type of node to wrap in. If it needs attributes,
+/// you can either pass them directly, or pass a function that will
+/// compute them from the regular expression match.
+///
+/// By default, if there's a node with the same type above the newly
+/// wrapped node, the rule will try to [join](#transform.Transform.join) those
+/// two nodes. You can pass a join predicate, which takes a regular
+/// expression match and the node before the wrapped node, and can
+
+import { type Attrs, type NodeType } from "prosemirror-model";
+import { canJoin, findWrapping } from "prosemirror-transform";
+import { getSuggestionMarks } from "./utils.js";
+import { ZWSP } from "./constants.js";
+
+/// return a boolean to indicate whether a join should happen.
+export function wrappingInputRule(
+  regexp: RegExp,
+  nodeType: NodeType,
+  getAttrs: Attrs | null | ((matches: RegExpMatchArray) => Attrs | null) = null,
+  joinPredicate?: (match: RegExpMatchArray, node: Node) => boolean,
+) {
+  return new InputRule(regexp, (state, match, start, end) => {
+    const attrs = getAttrs instanceof Function ? getAttrs(match) : getAttrs;
+    const tr = state.tr;
+
+    // check and try to preserve zwsp
+    const { insertion } = getSuggestionMarks(state.doc.type.schema);
+    let $start = tr.doc.resolve(start);
+    if (
+      insertion.isInSet($start.nodeAfter?.marks ?? []) &&
+      match[0].startsWith(ZWSP)
+    ) {
+      // preserve a single ZWSP at the start
+      tr.delete(start + 1, end);
+    } else {
+      tr.delete(start, end);
+    }
+
+    // the rest of the rule unchanged
+    $start = tr.doc.resolve(start);
+    const range = $start.blockRange(),
+      wrapping = range && findWrapping(range, nodeType, attrs);
+    if (!wrapping) return null;
+
+    tr.wrap(range, wrapping);
+
+    const before = tr.doc.resolve(start - 1).nodeBefore;
+    if (
+      before &&
+      before.type == nodeType &&
+      canJoin(tr.doc, start - 1) &&
+      (!joinPredicate || joinPredicate(match, before))
+    )
+      tr.join(start - 1);
+
+    return tr;
+  });
+}

--- a/test-fixtures/keyboard-test.html
+++ b/test-fixtures/keyboard-test.html
@@ -38,10 +38,26 @@
         font-family: monospace;
         font-size: 12px;
       }
+      [data-type="structure"] {
+        background-color: #b3d9ff;
+        color: #005c99;
+        mix-blend-mode: multiply;
+      }
+      blockquote {
+        border-left: 2px solid #000;
+        padding-left: 1rem;
+        margin-left: 1rem;
+      }
+      del,
+      [data-node-deletion] {
+        color: #9f003e;
+        background-color: #ffb7dc;
+      }
     </style>
   </head>
   <body>
     <h1>ProseMirror Keyboard Event Test</h1>
+    <div id="buttons"></div>
     <div id="editor"></div>
     <div id="status"></div>
     <script type="module" src="/test-fixtures/keyboard-test.ts"></script>

--- a/test-fixtures/keyboard-test.ts
+++ b/test-fixtures/keyboard-test.ts
@@ -1,21 +1,49 @@
-import { EditorState, TextSelection } from "prosemirror-state";
+import {
+  EditorState,
+  Selection,
+  TextSelection,
+  type Transaction,
+} from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
-import { type Mark, Schema } from "prosemirror-model";
-import { nodes, marks } from "prosemirror-schema-basic";
-import { baseKeymap, chainCommands } from "prosemirror-commands";
+import { type Mark, type Node } from "prosemirror-model";
 import { history, redo, undo } from "prosemirror-history";
+import {
+  baseKeymap,
+  chainCommands,
+  exitCode,
+  lift,
+  wrapIn,
+} from "prosemirror-commands";
 import { keymap } from "prosemirror-keymap";
 import {
-  bulletList,
-  orderedList,
-  listItem,
+  liftListItem,
+  sinkListItem,
   splitListItem,
 } from "prosemirror-schema-list";
-import { addSuggestionMarks } from "../src/schema.js";
 import { withSuggestChanges } from "../src/withSuggestChanges.js";
 import { suggestChanges, suggestChangesKey } from "../src/plugin.js";
 import "prosemirror-view/style/prosemirror.css";
-import { experimental_ensureSelection } from "../src/index.js";
+import {
+  experimental_ensureSelection,
+  revertSuggestions,
+} from "../src/index.js";
+import { type SuggestionId } from "../src/generateId.js";
+import * as commands from "../src/commands.js";
+import { createSchema } from "../src/testing/e2eTestSchema.js";
+import {
+  ensureUniqueNodeIds,
+  uniqueNodeIdsPlugin,
+} from "../src/features/wrapUnwrap/uniqueNodeIdsPlugin.js";
+import { inputRules } from "prosemirror-inputrules";
+import { listInputRules } from "../src/listInputRules.js";
+import { Step } from "prosemirror-transform";
+
+// stable node ids for tests
+let nodeId = 0;
+const generateUniqueNodeId = () => {
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+  return `node-${nodeId++}`;
+};
 
 const searchParams = new URLSearchParams(window.location.search);
 
@@ -31,22 +59,7 @@ console.log(
   deletionMarksVisibility,
 );
 
-// Create schema with suggestion marks and list support
-const schema = new Schema({
-  nodes: {
-    ...nodes,
-    ordered_list: { ...orderedList, group: "block", content: "list_item+" },
-    bullet_list: { ...bulletList, group: "block", content: "list_item+" },
-    list_item: {
-      ...listItem,
-      content: "block+",
-      marks: "insertion deletion modification",
-    },
-  },
-  marks: addSuggestionMarks(marks, {
-    experimental_deletions: deletionMarksVisibility,
-  }),
-});
+const schema = createSchema(deletionMarksVisibility);
 
 // Transaction logging
 const transactions: {
@@ -72,26 +85,53 @@ const enterCommand = baseKeymap["Enter"];
 if (!enterCommand) {
   throw new Error("Missing enter command");
 }
+
+const hardBreakCommand = chainCommands(exitCode, (state, dispatch) => {
+  if (dispatch) {
+    dispatch(
+      state.tr
+        .replaceSelectionWith(schema.nodes.hardBreak.create())
+        .scrollIntoView(),
+    );
+  }
+  return true;
+});
+
 // Create editor state with list item support
 let state = EditorState.create({
   doc,
   schema,
   plugins: [
-    experimental_ensureSelection(),
+    uniqueNodeIdsPlugin({
+      attributeName: "id",
+      generateID: generateUniqueNodeId,
+    }),
     keymap({
       ...baseKeymap,
       // Handle Enter key for list items
       Enter: chainCommands(
-        splitListItem(schema.nodes.list_item),
+        splitListItem(schema.nodes.listItem),
         baseKeymap["Enter"] ?? (() => false),
       ),
       "Shift-Enter": enterCommand,
+      "Mod-Enter": hardBreakCommand,
       "Mod-z": undo,
       "Mod-Shift-z": redo,
       "Mod-y": redo,
+      // handle lift and sink for list items
+      Tab: sinkListItem(schema.nodes.listItem),
+      "Shift-Tab": liftListItem(schema.nodes.listItem),
+      "Mod-u": wrapIn(schema.nodes.blockquote),
+      "Mod-l": lift,
+    }),
+    inputRules({
+      rules: [
+        ...listInputRules(schema.nodes.bulletList, schema.nodes.orderedList),
+      ],
     }),
     history(),
     suggestChanges(),
+    experimental_ensureSelection(),
   ],
 });
 
@@ -99,23 +139,43 @@ let state = EditorState.create({
 state = state.apply(state.tr.setMeta(suggestChangesKey, { enabled: true }));
 
 // Custom dispatch with logging
-const dispatch = withSuggestChanges(function (this: EditorView, tr) {
-  const docBefore = this.state.doc.textContent;
-  const newState = this.state.apply(tr);
+const dispatch = withSuggestChanges(
+  function (this: EditorView, tr) {
+    const docBefore = this.state.doc.textContent;
+    const newState = this.state.apply(tr);
 
-  transactions.push({
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    steps: tr.steps.map((s) => s.toJSON()),
-    selection: { from: tr.selection.from, to: tr.selection.to },
-    docBefore,
-    docAfter: newState.doc.textContent,
-  });
+    transactions.push({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      steps: tr.steps.map((s) => s.toJSON()),
+      selection: { from: tr.selection.from, to: tr.selection.to },
+      docBefore,
+      docAfter: newState.doc.textContent,
+    });
 
-  this.updateState(newState);
+    this.updateState(newState);
 
-  // Update status display
-  updateStatus();
-});
+    // Update status display
+    updateStatus();
+  },
+  undefined,
+  {
+    experimental_trackStructureChanges: true,
+    experimental_trackStructures: [
+      ["orderedList", "listItem"],
+      ["bulletList", "listItem"],
+      ["blockquote"],
+    ],
+    experimental_ensureUniqueNodeIds: (
+      transactions: Transaction[],
+      oldDoc: Node,
+      newDoc: Node,
+    ) =>
+      ensureUniqueNodeIds(transactions, oldDoc, newDoc, {
+        attributeName: "id",
+        generateID: generateUniqueNodeId,
+      }),
+  },
+);
 
 // Create editor view
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -140,13 +200,39 @@ function updateStatus() {
   ].join(" | ");
 }
 
+function renderButtons() {
+  const applyAllButton = document.createElement("button");
+  applyAllButton.appendChild(document.createTextNode("Apply all"));
+  applyAllButton.addEventListener("click", () => {
+    commands.applySuggestions(view.state, view.dispatch);
+    view.focus();
+  });
+
+  const revertAllButton = document.createElement("button");
+  revertAllButton.appendChild(document.createTextNode("Revert all"));
+  revertAllButton.addEventListener("click", () => {
+    revertSuggestions(view.state, view.dispatch);
+    view.focus();
+  });
+  const container = document.getElementById("buttons");
+  if (!container) {
+    throw new Error("Buttons container not found");
+  }
+  container.append(applyAllButton, revertAllButton);
+}
+
 // Initial status
 updateStatus();
+
+renderButtons();
 
 // Expose API to window for Playwright access
 declare global {
   interface Window {
     pmEditor: {
+      __prevState: EditorState;
+      __prevAnchor: number;
+      __prevHead: number;
       view: EditorView;
       getState: () => {
         blockCount: number;
@@ -156,7 +242,7 @@ declare global {
         cursorTo: number;
         marks: Mark[];
       };
-      getDocJSON: () => unknown;
+      getDocJSON: () => object;
       replaceDoc: (docJSON: unknown) => void;
       getCursorInfo: () => {
         from: number;
@@ -172,15 +258,34 @@ declare global {
       clearTransactions: () => void;
       logState: () => void;
       getProseMirrorMarkCount: (name: string) => number;
+      getProseMirrorMarksJSON: () => unknown[];
       getProseMirrorSelection: () => { anchor: number; head: number };
-      getTextContentOfChildAtIndex: (index: number) => string;
+      getTextContentOfChildAtIndex: (
+        index: number,
+        childIndexes?: number[],
+      ) => string;
       getDOMTextContentOfChildAtIndex: (index: number) => string;
+      dispatchTransactionWithSteps: (
+        stepJSONs: object[],
+        selection?: { type: string; anchor: number; head: number },
+      ) => void;
+      setSuggestChangesEnabled: (enabled: boolean) => void;
+      revertSuggestion: (
+        suggestionId: SuggestionId,
+        opts?: { structure: boolean },
+      ) => void;
+      revertStructureSuggestion: (suggestionId: SuggestionId) => void;
+      setNextNodeId: (nextNodeId: number) => void;
     };
   }
 }
 
 window.pmEditor = {
   view,
+
+  __prevState: view.state,
+  __prevAnchor: view.state.selection.anchor,
+  __prevHead: view.state.selection.head,
 
   getState() {
     const marks: Mark[] = [];
@@ -217,8 +322,7 @@ window.pmEditor = {
   },
 
   getDocJSON() {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return view.state.doc.toJSON();
+    return view.state.doc.toJSON() as object;
   },
 
   getCursorInfo() {
@@ -300,16 +404,73 @@ window.pmEditor = {
     return marks.filter((mark) => mark.type.name === name).length;
   },
 
+  getProseMirrorMarksJSON() {
+    const marks: Mark[] = [];
+    view.state.doc.nodesBetween(0, view.state.doc.content.size, (node) => {
+      marks.push(...node.marks);
+    });
+    return marks.map((mark): unknown => mark.toJSON());
+  },
+
   getProseMirrorSelection() {
     return view.state.selection.toJSON() as { anchor: number; head: number };
   },
 
-  getTextContentOfChildAtIndex(index: number) {
-    return view.state.doc.child(index).textContent;
+  getTextContentOfChildAtIndex(index: number, childIndexes?: number[]): string {
+    let node = view.state.doc.child(index);
+    if (childIndexes) {
+      for (const childIndex of childIndexes) {
+        node = node.child(childIndex);
+      }
+    }
+    return node.textContent;
   },
 
   getDOMTextContentOfChildAtIndex(index: number) {
     return view.dom.childNodes[index].textContent ?? "";
+  },
+
+  dispatchTransactionWithSteps(
+    stepJSONs: object[],
+    selection?: { type: string; anchor: number; head: number },
+  ) {
+    const steps = stepJSONs.map((stepJSON) =>
+      Step.fromJSON(view.state.schema, stepJSON),
+    );
+    const tr = view.state.tr;
+    steps.forEach((step) => tr.step(step));
+    if (selection) {
+      tr.setSelection(Selection.fromJSON(tr.doc, selection));
+    }
+    view.dispatch(tr);
+  },
+
+  setSuggestChangesEnabled(enabled: boolean) {
+    view.dispatch(
+      view.state.tr.setMeta(suggestChangesKey, { skip: true, enabled }),
+    );
+  },
+
+  revertSuggestion(suggestionId: SuggestionId) {
+    const command = commands.revertSuggestion(
+      suggestionId,
+      undefined,
+      undefined,
+    );
+    command(view.state, view.dispatch);
+  },
+
+  revertStructureSuggestion(suggestionId: SuggestionId) {
+    const command = commands.revertSuggestion(
+      suggestionId,
+      undefined,
+      undefined,
+    );
+    command(view.state, view.dispatch);
+  },
+
+  setNextNodeId(nextNodeId: number) {
+    nodeId = nextNodeId;
   },
 };
 

--- a/test-fixtures/keyboard-test.ts
+++ b/test-fixtures/keyboard-test.ts
@@ -251,6 +251,7 @@ declare global {
         parentOffset: number;
         depth: number;
       };
+      setCursorToStart: () => void;
       setCursorToEnd: () => void;
       setCursorToPosition: (pos: number) => void;
       setCursorToEndOfBlock: (blockIndex: number) => void;
@@ -335,6 +336,12 @@ window.pmEditor = {
       parentOffset: $from.parentOffset,
       depth: $from.depth,
     };
+  },
+
+  setCursorToStart() {
+    view.dispatch(
+      view.state.tr.setSelection(TextSelection.near(view.state.doc.resolve(0))),
+    );
   },
 
   setCursorToEnd() {


### PR DESCRIPTION
## Summary

Adds experimental ID-based Structure suggestion tracking for configured structural contexts such as lists and blockquotes.

The plugin compares stable node IDs and Parent chains before and after editor transactions, then records Structure add and move suggestions on stable content nodes. It supports apply/revert, provisional add behavior, inverse move cancellation, split-derived text fallthrough, and interaction with Block join suggestions.

## Verification

- Unit coverage for materialized Parent chains, split detection, join metadata, and command behavior
- Playwright coverage for list, blockquote, apply, revert, and text-edit interactions
- Documentation aligned to the current Structure suggestion vocabulary and ADR decisions