### PR TITLE
Clean up no-op deletion/insertion mark pairs

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -15,6 +15,8 @@ Context docs live under `src`.
   range.
 - Ensure Valid Selection - cursor and text-selection positions that suggestion
   markers make unsafe for normal editing.
+- Cleanup No-op Mark Pairs - detection and cleanup of deletion/insertion mark
+  pairs that no longer represent a meaningful user-visible change.
 
 ## Relationships
 

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -134,11 +134,11 @@ const remarkProseMirrorOptions: RemarkProseMirrorOptions = {
   },
 };
 
-const content = `- Item 1
-- Item 2
-- Item 3
-- Item 4
-- Item 5
+const content = `Paragraph 1
+
+Paragraph 2
+
+Paragraph 3
 `;
 
 const doc = await unified()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-marker/prosemirror-suggest-changes",
-  "version": "0.5.2-noop-mark-pairs.0",
+  "version": "0.5.2-noop-mark-pairs.1",
   "license": "MIT",
   "type": "module",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magic-marker/prosemirror-suggest-changes",
-  "version": "0.5.1",
+  "version": "0.5.2-noop-mark-pairs.0",
   "license": "MIT",
   "type": "module",
   "module": "dist/index.js",

--- a/src/__tests__/marks.playwright.test.ts
+++ b/src/__tests__/marks.playwright.test.ts
@@ -104,4 +104,91 @@ test.describe("Behavior around adding and removing marks", () => {
     expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(0);
     expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
   });
+
+  test("should have the cursor at the correct position after making a whole textblock bold", async ({
+    page,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page);
+    await editorPage.enableTrackChanges();
+
+    // move to "|Hello world"
+    await editorPage.pressKey("Home", { waitForSelectionChange: true });
+
+    // select "Hello world"
+    await editorPage.pressKey("Shift+ArrowDown", {
+      waitForSelectionChange: true,
+    });
+
+    // make bold
+    await editorPage.pressKey("ControlOrMeta+b");
+
+    // collapse selection to the left
+    await editorPage.pressKey("ArrowLeft", { waitForSelectionChange: true });
+
+    // insert some text to verify the cursor position
+    await editorPage.insertText("FOO");
+
+    await expect(editorPage.getParagraphAt(0)).toHaveText(
+      "Hello worldFOOHello world",
+    );
+  });
+
+  test("should have the cursor at the correct position after making part of a textblock bold", async ({
+    page,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page);
+    await editorPage.enableTrackChanges();
+
+    // move to "|Hello world"
+    await editorPage.pressKey("Home", { waitForSelectionChange: true });
+
+    // move to "H|ello world"
+    await editorPage.pressKey("ArrowRight", { waitForSelectionChange: true });
+
+    // select "ello world"
+    await editorPage.pressKey("Shift+ArrowDown", {
+      waitForSelectionChange: true,
+    });
+
+    // make bold
+    await editorPage.pressKey("ControlOrMeta+b");
+
+    // collapse selection to the left
+    await editorPage.pressKey("ArrowLeft", { waitForSelectionChange: true });
+
+    // insert some text to verify the cursor position
+    await editorPage.insertText("FOO");
+
+    await expect(editorPage.getParagraphAt(0)).toHaveText(
+      "Hello worldFOOello world",
+    );
+  });
 });

--- a/src/__tests__/marks.playwright.test.ts
+++ b/src/__tests__/marks.playwright.test.ts
@@ -1,0 +1,107 @@
+import { test, expect } from "./playwrightBaseTest.js";
+import { setupDocFromJSON } from "./playwrightHelpers.js";
+import { EditorPage } from "./playwrightPage.js";
+
+test.describe("Behavior around adding and removing marks", () => {
+  test("should be able to make text bold in a single paragraph and unbold", async ({
+    page,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page);
+    await editorPage.enableTrackChanges();
+
+    await expect(editorPage.editor.locator("strong")).toHaveCount(0);
+    expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(0);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+
+    // move to "Hello wo|rld"
+    await editorPage.pressKeyMultiple("ArrowLeft", 3);
+
+    // select "lo wo"
+    await editorPage.pressKeyMultiple("Shift+ArrowLeft", "lo wo".length);
+
+    // make bold
+    await editorPage.pressKey("ControlOrMeta+b");
+
+    await expect(editorPage.editor.locator("strong")).toHaveCount(1);
+    await expect(editorPage.editor.locator("strong")).toHaveText("lo wo");
+
+    expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(1);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(1);
+
+    // unbold
+    await editorPage.pressKey("ControlOrMeta+b");
+
+    await expect(editorPage.editor.locator("strong")).toHaveCount(0);
+    expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(0);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+  });
+
+  test("should be able to make text bold in multiple paragraphs and unbold", async ({
+    page,
+  }) => {
+    await setupDocFromJSON(page, {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Foo bar" }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      ],
+    });
+
+    await page.evaluate(() => {
+      window.pmEditor.setCursorToEnd();
+    });
+
+    const editorPage = new EditorPage(page);
+    await editorPage.enableTrackChanges();
+
+    await expect(editorPage.editor.locator("strong")).toHaveCount(0);
+    expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(0);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+
+    // move to "Hello| world"
+    await editorPage.pressKeyMultiple("ArrowLeft", " world".length);
+
+    // select up to "bar" in the above paragraph
+    await editorPage.pressKeyMultiple("Shift+ArrowLeft", "bar Hello".length);
+
+    // make bold
+    await editorPage.pressKey("ControlOrMeta+b");
+
+    await expect(editorPage.editor.locator("strong")).toHaveCount(2);
+    await expect(editorPage.editor.locator("strong")).toHaveText([
+      "bar",
+      "Hello",
+    ]);
+
+    expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(2);
+    // one additional deletion mark - the deletion "anchor" mark in front of "Hello"
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(3);
+
+    // unbold
+    await editorPage.pressKey("ControlOrMeta+b");
+
+    await expect(editorPage.editor.locator("strong")).toHaveCount(0);
+    expect(await editorPage.getProseMirrorMarkCount("insertion")).toBe(0);
+    expect(await editorPage.getProseMirrorMarkCount("deletion")).toBe(0);
+  });
+});

--- a/src/features/cleanupNoopMarkPairs/CONTEXT.md
+++ b/src/features/cleanupNoopMarkPairs/CONTEXT.md
@@ -1,0 +1,16 @@
+# Cleanup No-op Mark Pairs
+
+This context defines the language for identifying suggestion mark pairs that no
+longer represent a meaningful user-visible change.
+
+## Language
+
+**Deletion/Insertion Mark Pair**: A `deletion` mark run immediately followed by
+an `insertion` mark run in the same textblock, with the same suggestion id.
+_Avoid_: mark pair
+
+**No-op Deletion/Insertion Mark Pair**: A Deletion/Insertion Mark Pair whose
+deletion and insertion runs have identical inline content after removing only
+suggestion marks. Identical inline content means the same text and the same
+non-suggestion marks with the same attributes. _Avoid_: stale suggestion,
+redundant suggestion, cancellation, no-op mark pair

--- a/src/features/cleanupNoopMarkPairs/__tests__/cleanupNoopDeletionInsertionPairs.test.ts
+++ b/src/features/cleanupNoopMarkPairs/__tests__/cleanupNoopDeletionInsertionPairs.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import { EditorState } from "prosemirror-state";
+import { eq } from "prosemirror-test-builder";
+import { assert, describe, it } from "vitest";
+
+import { cleanupNoopDeletionInsertionPairs, type Range } from "../index.js";
+import {
+  type TaggedNode,
+  testBuilders,
+} from "../../../testing/testBuilders.js";
+
+describe("cleanupNoopDeletionInsertionPairs", () => {
+  it("removes equal plain-text no-op pair, leaving one unmarked copy", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "<a>",
+        testBuilders.deletion({ id: 1 }, "foo"),
+        testBuilders.insertion({ id: 1 }, "foo"),
+        "<b>",
+      ),
+    ) as TaggedNode;
+
+    const result = cleanupDoc(doc, rangeFromTags(doc));
+
+    assert(eq(result, testBuilders.doc(testBuilders.paragraph("foo"))));
+  });
+
+  it("removes no-op pair with matching non-suggestion marks, preserving those marks", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "<a>",
+        testBuilders.deletion({ id: 1 }, testBuilders.strong("foo")),
+        testBuilders.insertion({ id: 1 }, testBuilders.strong("foo")),
+        "<b>",
+      ),
+    ) as TaggedNode;
+
+    const result = cleanupDoc(doc, rangeFromTags(doc));
+
+    assert(
+      eq(
+        result,
+        testBuilders.doc(testBuilders.paragraph(testBuilders.strong("foo"))),
+      ),
+    );
+  });
+
+  it("removes multiple pairs in one transaction", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "<a>",
+        testBuilders.deletion({ id: 1 }, "foo"),
+        testBuilders.insertion({ id: 1 }, "foo"),
+        " middle ",
+        testBuilders.deletion({ id: 2 }, "bar"),
+        testBuilders.insertion({ id: 2 }, "bar"),
+        "<b>",
+      ),
+    ) as TaggedNode;
+
+    const result = cleanupDoc(doc, rangeFromTags(doc));
+
+    assert(
+      eq(result, testBuilders.doc(testBuilders.paragraph("foo middle bar"))),
+    );
+  });
+
+  it("ignores non-noop pair", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "<a>",
+        testBuilders.deletion({ id: 1 }, "foo"),
+        testBuilders.insertion({ id: 1 }, "bar"),
+        "<b>",
+      ),
+    ) as TaggedNode;
+
+    const result = cleanupDoc(doc, rangeFromTags(doc));
+
+    assert(eq(result, doc));
+  });
+
+  it("ignores structurally invalid candidates", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "<a>",
+        testBuilders.insertion({ id: 1 }, "foo"),
+        testBuilders.deletion({ id: 1 }, "foo"),
+        testBuilders.deletion({ id: 2 }, "bar"),
+        testBuilders.insertion({ id: 3 }, "bar"),
+        testBuilders.deletion({ id: 4 }, "baz"),
+        " gap ",
+        testBuilders.insertion({ id: 4 }, "baz"),
+        "<b>",
+      ),
+    ) as TaggedNode;
+
+    const result = cleanupDoc(doc, rangeFromTags(doc));
+
+    assert(eq(result, doc));
+  });
+});
+
+function cleanupDoc(doc: TaggedNode, ranges: Range[]) {
+  const transaction = EditorState.create({ doc }).tr;
+  cleanupNoopDeletionInsertionPairs(transaction, ranges);
+  return transaction.doc;
+}
+
+function rangeFromTags(doc: TaggedNode) {
+  return [{ from: doc.tag["a"]!, to: doc.tag["b"]! }];
+}

--- a/src/features/cleanupNoopMarkPairs/__tests__/findNoopDeletionInsertionPairs.test.ts
+++ b/src/features/cleanupNoopMarkPairs/__tests__/findNoopDeletionInsertionPairs.test.ts
@@ -1,0 +1,174 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import { assert, describe, it } from "vitest";
+
+import {
+  findNoopDeletionInsertionPairs,
+  type Range,
+  type SuggestionPair,
+} from "../index.js";
+import {
+  type TaggedNode,
+  testBuilders,
+} from "../../../testing/testBuilders.js";
+
+describe("findNoopDeletionInsertionPairs", () => {
+  it("returns a pair for equal deletion/insertion text with no remaining marks", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "<a>",
+        testBuilders.deletion({ id: 1 }, "foo"),
+        testBuilders.insertion({ id: 1 }, "foo"),
+        "<b>",
+      ),
+    ) as TaggedNode;
+
+    assert.deepEqual(simplifyPairs(doc, rangeFromTags(doc)), [
+      {
+        id: 1,
+        deletion: "foo",
+        insertion: "foo",
+      },
+    ]);
+  });
+
+  it("returns a pair when equivalent content has different incidental text-node segmentation", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "<a>",
+        testBuilders.deletion({ id: 1, type: "first" }, "f"),
+        testBuilders.deletion({ id: 1, type: "second" }, "oo"),
+        testBuilders.insertion({ id: 1 }, "foo"),
+        "<b>",
+      ),
+    ) as TaggedNode;
+
+    assert.deepEqual(simplifyPairs(doc, rangeFromTags(doc)), [
+      {
+        id: 1,
+        deletion: "foo",
+        insertion: "foo",
+      },
+    ]);
+  });
+
+  it("returns a pair when equal text has the same non-suggestion mark boundaries", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "<a>",
+        testBuilders.deletion({ id: 1 }, "fo"),
+        testBuilders.deletion({ id: 1 }, testBuilders.strong("o")),
+        testBuilders.insertion({ id: 1 }, "fo"),
+        testBuilders.insertion({ id: 1 }, testBuilders.strong("o")),
+        "<b>",
+      ),
+    ) as TaggedNode;
+
+    assert.deepEqual(simplifyPairs(doc, rangeFromTags(doc)), [
+      {
+        id: 1,
+        deletion: "foo",
+        insertion: "foo",
+      },
+    ]);
+  });
+
+  it("ignores same text with different non-suggestion mark boundaries", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "<a>",
+        testBuilders.deletion({ id: 1 }, "fo"),
+        testBuilders.deletion({ id: 1 }, testBuilders.strong("o")),
+        testBuilders.insertion({ id: 1 }, "f"),
+        testBuilders.insertion({ id: 1 }, testBuilders.strong("oo")),
+        "<b>",
+      ),
+    ) as TaggedNode;
+
+    assert.deepEqual(simplifyPairs(doc, rangeFromTags(doc)), []);
+  });
+
+  it("ignores same text with different mark attrs", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "<a>",
+        testBuilders.deletion(
+          { id: 1 },
+          testBuilders.difficulty({ level: "beginner" }, "foo"),
+        ),
+        testBuilders.insertion(
+          { id: 1 },
+          testBuilders.difficulty({ level: "advanced" }, "foo"),
+        ),
+        "<b>",
+      ),
+    ) as TaggedNode;
+
+    assert.deepEqual(simplifyPairs(doc, rangeFromTags(doc)), []);
+  });
+
+  it("ignores different text", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "<a>",
+        testBuilders.deletion({ id: 1 }, "foo"),
+        testBuilders.insertion({ id: 1 }, "bar"),
+        "<b>",
+      ),
+    ) as TaggedNode;
+
+    assert.deepEqual(simplifyPairs(doc, rangeFromTags(doc)), []);
+  });
+
+  it("preserves structural filters", () => {
+    const doc = testBuilders.doc(
+      testBuilders.paragraph(
+        "<a>",
+        testBuilders.insertion({ id: 1 }, "foo"),
+        testBuilders.deletion({ id: 1 }, "foo"),
+        testBuilders.deletion({ id: 2 }, "bar"),
+        testBuilders.insertion({ id: 3 }, "bar"),
+        testBuilders.deletion({ id: 4 }, "baz"),
+        " gap ",
+        testBuilders.insertion({ id: 4 }, "baz"),
+        testBuilders.deletion({ id: 5 }, "qux"),
+        "<split>",
+        testBuilders.insertion({ id: 5 }, "qux"),
+        "<b>",
+      ),
+    ) as TaggedNode;
+
+    assert.deepEqual(
+      simplifyPairs(doc, [
+        { from: doc.tag["a"]!, to: doc.tag["split"]! },
+        { from: doc.tag["split"]!, to: doc.tag["b"]! },
+        { from: doc.tag["a"]!, to: doc.tag["b"]! },
+      ]),
+      [
+        {
+          id: 5,
+          deletion: "qux",
+          insertion: "qux",
+        },
+      ],
+    );
+  });
+});
+
+function simplifyPairs(doc: TaggedNode, ranges: Range[]) {
+  return findNoopDeletionInsertionPairs(doc, ranges).map((pair) =>
+    simplifyPair(doc, pair),
+  );
+}
+
+function simplifyPair(doc: TaggedNode, pair: SuggestionPair) {
+  return {
+    id: pair.deletion.id,
+    deletion: doc.textBetween(pair.deletion.from, pair.deletion.to),
+    insertion: doc.textBetween(pair.insertion.from, pair.insertion.to),
+  };
+}
+
+function rangeFromTags(doc: TaggedNode) {
+  return [{ from: doc.tag["a"]!, to: doc.tag["b"]! }];
+}

--- a/src/features/cleanupNoopMarkPairs/cleanupNoopDeletionInsertionPairs.ts
+++ b/src/features/cleanupNoopMarkPairs/cleanupNoopDeletionInsertionPairs.ts
@@ -1,0 +1,34 @@
+import { type Transaction } from "prosemirror-state";
+import { Transform } from "prosemirror-transform";
+
+import { getSuggestionMarks } from "../../utils.js";
+import { findNoopDeletionInsertionPairs } from "./findNoopDeletionInsertionPairs.js";
+import { type Range } from "./types.js";
+
+/**
+ * Find no-op deletion/insertion pairs and remove them
+ * Leaving only one copy of their content behind
+ */
+export function cleanupNoopDeletionInsertionPairs(
+  transaction: Transaction,
+  ranges: Range[],
+): Transaction {
+  const { deletion } = getSuggestionMarks(transaction.doc.type.schema);
+
+  // process right to left so we don't need to rebase positions
+  const pairs = findNoopDeletionInsertionPairs(transaction.doc, ranges)
+    .slice()
+    .sort((a, b) => b.deletion.from - a.deletion.from);
+  const transform = new Transform(transaction.doc);
+
+  for (const pair of pairs) {
+    transform.delete(pair.insertion.from, pair.insertion.to);
+    transform.removeMark(pair.deletion.from, pair.deletion.to, deletion);
+  }
+
+  transform.steps.forEach((step) => {
+    transaction.step(step);
+  });
+
+  return transaction;
+}

--- a/src/features/cleanupNoopMarkPairs/collectSuggestionRunsInTextblock.ts
+++ b/src/features/cleanupNoopMarkPairs/collectSuggestionRunsInTextblock.ts
@@ -1,0 +1,87 @@
+import { type Node } from "prosemirror-model";
+
+import { type SuggestionId } from "../../generateId.js";
+import { getSuggestionMarks } from "../../utils.js";
+import { type SuggestionRun, type TextblockRange } from "./types.js";
+
+/**
+ * Finds contiguous suggestion runs inside textblocks so later stages can pair
+ * runs structurally instead of reinterpreting individual text nodes.
+ */
+export function collectSuggestionRunsInTextblock(
+  doc: Node,
+  textblockRange: TextblockRange,
+): SuggestionRun[] {
+  const { deletion, insertion } = getSuggestionMarks(doc.type.schema);
+  const runs: SuggestionRun[] = [];
+  let currentRun: SuggestionRun | null = null;
+
+  // A run is meaningful only while suggestion-marked text is contiguous. Any
+  // interruption makes the next suggestion text a separate cleanup candidate.
+  const flush = () => {
+    if (!currentRun) return;
+    runs.push(currentRun);
+    currentRun = null;
+  };
+
+  doc.nodesBetween(textblockRange.from, textblockRange.to, (node, pos) => {
+    if (!node.isText) {
+      // Non-text inline content may have its own semantics. For this first pass,
+      // it is a hard boundary rather than something to compare or collapse.
+      flush();
+      return true;
+    }
+
+    // starting and ending position of this text node
+    const from = pos;
+    const to = pos + node.nodeSize;
+
+    const deletionMark = deletion.isInSet(node.marks);
+    const insertionMark = insertion.isInSet(node.marks);
+
+    let kind: SuggestionRun["kind"];
+    let id: SuggestionId;
+
+    if (deletionMark) {
+      kind = "deletion";
+      id = deletionMark.attrs["id"] as SuggestionId;
+    } else if (insertionMark) {
+      kind = "insertion";
+      id = insertionMark.attrs["id"] as SuggestionId;
+    } else {
+      // Unmarked text is a real gap between suggestions, so the next marked text
+      // must start a separate cleanup candidate.
+      flush();
+      return false;
+    }
+
+    // if current node kind matches the current run kind, extend the current run
+    if (
+      currentRun &&
+      currentRun.kind === kind &&
+      currentRun.id === id &&
+      currentRun.to === from
+    ) {
+      // ProseMirror can split adjacent text by non-suggestion marks. Keep them
+      // in one run when the suggestion identity is still continuous.
+      currentRun.to = to;
+      currentRun.segments.push({ from, to, node });
+      return false;
+    }
+
+    // otherwise flush the current run and initialize a new one
+    flush();
+    currentRun = {
+      kind,
+      id,
+      from,
+      to,
+      segments: [{ from, to, node }],
+    };
+
+    return false;
+  });
+
+  flush();
+  return runs;
+}

--- a/src/features/cleanupNoopMarkPairs/docs/adr/0001-centralized-noop-deletion-insertion-cleanup.md
+++ b/src/features/cleanupNoopMarkPairs/docs/adr/0001-centralized-noop-deletion-insertion-cleanup.md
@@ -1,0 +1,12 @@
+# Centralized No-op Deletion/Insertion Cleanup
+
+No-op deletion/insertion pairs can arise from mark toggles, but the same shape
+can also appear after ordinary tracked text edits later become equivalent again.
+Clean these pairs in one changed-range-scoped transaction pass instead of inside
+individual mark-step handlers, so cleanup is tied to the resulting suggestion
+shape rather than to the command that happened to create it.
+
+The cleanup keeps the deletion-side content, removes its `deletion` mark, and
+deletes the duplicate insertion-side content. It runs before deletion-anchor
+insertion so transient no-op deletion marks do not get anchored by
+`prependDeletionsWithZWSP`.

--- a/src/features/cleanupNoopMarkPairs/findNoopDeletionInsertionPairs.ts
+++ b/src/features/cleanupNoopMarkPairs/findNoopDeletionInsertionPairs.ts
@@ -1,0 +1,24 @@
+import { type Node } from "prosemirror-model";
+
+import { getSuggestionMarks } from "../../utils.js";
+import { collectSuggestionRunsInTextblock } from "./collectSuggestionRunsInTextblock.js";
+import { getCandidateTextblockRanges } from "./getCandidateTextblockRanges.js";
+import { isNoopDeletionInsertionPair } from "./isNoopDeletionInsertionPair.js";
+import { pairAdjacentDeletionInsertionRuns } from "./pairAdjacentDeletionInsertionRuns.js";
+import { type Range, type SuggestionPair } from "./types.js";
+
+/**
+ * Find no-op deletion/insertion pairs in the given ranges
+ */
+export function findNoopDeletionInsertionPairs(
+  doc: Node,
+  ranges: Range[],
+): SuggestionPair[] {
+  const { deletion, insertion } = getSuggestionMarks(doc.type.schema);
+
+  return getCandidateTextblockRanges(doc, ranges).flatMap((textblockRange) =>
+    pairAdjacentDeletionInsertionRuns(
+      collectSuggestionRunsInTextblock(doc, textblockRange),
+    ).filter((pair) => isNoopDeletionInsertionPair(pair, deletion, insertion)),
+  );
+}

--- a/src/features/cleanupNoopMarkPairs/getCandidateTextblockRanges.ts
+++ b/src/features/cleanupNoopMarkPairs/getCandidateTextblockRanges.ts
@@ -1,0 +1,60 @@
+import { type Node } from "prosemirror-model";
+
+import { mergeRanges } from "./mergeRanges.js";
+import { type Range, type TextblockRange } from "./types.js";
+
+/**
+ * Expands changed ranges to whole textblock content ranges because a no-op pair
+ * may start just outside the exact step map range but cannot cross textblocks.
+ */
+export function getCandidateTextblockRanges(
+  doc: Node,
+  ranges: Range[],
+): TextblockRange[] {
+  const textblockRanges: TextblockRange[] = [];
+
+  for (const range of mergeRanges(ranges)) {
+    const { from, to } = range;
+    if (from >= to) continue;
+
+    const $from = doc.resolve(from);
+    // `to` is exclusive. Resolving `to - 1` anchors the block range in content
+    // that actually belongs to this changed window.
+    const $to = doc.resolve(to - 1);
+    const blockRange = $from.blockRange($to);
+    if (!blockRange) continue;
+
+    doc.nodesBetween(blockRange.start, blockRange.end, (node, pos) => {
+      if (!node.isTextblock) return true;
+
+      const textblockRange = {
+        from: pos + 1,
+        to: pos + node.nodeSize - 1,
+      };
+      // The block range can include neighboring textblocks in the same parent
+      // structure; only scan textblocks that the original seed actually touched.
+      const overlapsRange =
+        textblockRange.from < to && textblockRange.to > from;
+      if (overlapsRange) {
+        textblockRanges.push(textblockRange);
+      }
+
+      return false;
+    });
+  }
+
+  // make sure we don't have duplicated textblock ranges
+  // meaning ranges that cover the same textblock
+  const seenRanges = new Set<string>();
+  const uniqueRanges: TextblockRange[] = [];
+  for (const range of textblockRanges) {
+    // Multiple changed ranges can expand to the same textblock. Deduping here
+    // prevents duplicate pairs without making callers reason about scan windows.
+    const key = `${String(range.from)}:${String(range.to)}`;
+    if (seenRanges.has(key)) continue;
+    seenRanges.add(key);
+    uniqueRanges.push(range);
+  }
+
+  return uniqueRanges;
+}

--- a/src/features/cleanupNoopMarkPairs/index.ts
+++ b/src/features/cleanupNoopMarkPairs/index.ts
@@ -1,0 +1,3 @@
+export { cleanupNoopDeletionInsertionPairs } from "./cleanupNoopDeletionInsertionPairs.js";
+export { findNoopDeletionInsertionPairs } from "./findNoopDeletionInsertionPairs.js";
+export type { Range, SuggestionPair } from "./types.js";

--- a/src/features/cleanupNoopMarkPairs/isNoopDeletionInsertionPair.ts
+++ b/src/features/cleanupNoopMarkPairs/isNoopDeletionInsertionPair.ts
@@ -1,0 +1,45 @@
+import { Mark, type MarkType } from "prosemirror-model";
+
+import { normalizeSuggestionRun } from "./normalizeSuggestionRun.js";
+import { type SuggestionPair } from "./types.js";
+
+/**
+ * Decides whether a structural deletion/insertion pair has no user-visible
+ * difference once suggestion marks themselves are ignored.
+ */
+export function isNoopDeletionInsertionPair(
+  pair: SuggestionPair,
+  deletion: MarkType,
+  insertion: MarkType,
+) {
+  const deletionSegments = normalizeSuggestionRun(
+    pair.deletion,
+    deletion,
+    insertion,
+  );
+  const insertionSegments = normalizeSuggestionRun(
+    pair.insertion,
+    deletion,
+    insertion,
+  );
+
+  if (deletionSegments.length !== insertionSegments.length) return false;
+
+  for (let index = 0; index < deletionSegments.length; index++) {
+    // The length check above proves both indexed segments exist; the assertions
+    // keep noUncheckedIndexedAccess from forcing impossible runtime branches.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const deletionSegment = deletionSegments[index]!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const insertionSegment = insertionSegments[index]!;
+
+    if (
+      deletionSegment.text !== insertionSegment.text ||
+      !Mark.sameSet(deletionSegment.marks, insertionSegment.marks)
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/features/cleanupNoopMarkPairs/mergeRanges.ts
+++ b/src/features/cleanupNoopMarkPairs/mergeRanges.ts
@@ -1,0 +1,27 @@
+import { type Range } from "./types.js";
+
+/**
+ * Normalizes changed ranges before we expand them to textblocks, so adjacent
+ * steps in one user transaction do not make us scan the same area repeatedly.
+ */
+export function mergeRanges(ranges: Range[]): Range[] {
+  const sortedRanges = ranges
+    .filter((range) => range.from < range.to)
+    .slice()
+    .sort((a, b) => a.from - b.from || a.to - b.to);
+
+  const mergedRanges: Range[] = [];
+  for (const range of sortedRanges) {
+    const previousRange = mergedRanges[mergedRanges.length - 1];
+    // Touching intervals can share a deletion/insertion pair at the boundary,
+    // so treat them as one search window instead of two independent windows.
+    if (!previousRange || range.from > previousRange.to) {
+      mergedRanges.push({ ...range });
+      continue;
+    }
+
+    previousRange.to = Math.max(previousRange.to, range.to);
+  }
+
+  return mergedRanges;
+}

--- a/src/features/cleanupNoopMarkPairs/normalizeSuggestionRun.ts
+++ b/src/features/cleanupNoopMarkPairs/normalizeSuggestionRun.ts
@@ -1,0 +1,37 @@
+import { Mark, type MarkType } from "prosemirror-model";
+
+import { type SuggestionRun } from "./types.js";
+
+interface NormalizedInlineSegment {
+  text: string;
+  marks: readonly Mark[];
+}
+
+/**
+ * Removes suggestion-only metadata from a run so no-op detection compares the
+ * inline content users see, not incidental ProseMirror text-node boundaries.
+ */
+export function normalizeSuggestionRun(
+  run: SuggestionRun,
+  deletion: MarkType,
+  insertion: MarkType,
+): NormalizedInlineSegment[] {
+  const normalizedSegments: NormalizedInlineSegment[] = [];
+
+  for (const segment of run.segments) {
+    const text = segment.node.text ?? "";
+    const marks = segment.node.marks.filter(
+      (mark) => mark.type !== deletion && mark.type !== insertion,
+    );
+    const previousSegment = normalizedSegments[normalizedSegments.length - 1];
+
+    if (previousSegment && Mark.sameSet(previousSegment.marks, marks)) {
+      previousSegment.text += text;
+      continue;
+    }
+
+    normalizedSegments.push({ text, marks });
+  }
+
+  return normalizedSegments;
+}

--- a/src/features/cleanupNoopMarkPairs/pairAdjacentDeletionInsertionRuns.ts
+++ b/src/features/cleanupNoopMarkPairs/pairAdjacentDeletionInsertionRuns.ts
@@ -1,0 +1,35 @@
+import { type SuggestionPair, type SuggestionRun } from "./types.js";
+
+/**
+ * Finds structural Deletion/Insertion Mark Pairs without deciding whether the
+ * paired content is semantically no-op.
+ */
+export function pairAdjacentDeletionInsertionRuns(
+  runs: SuggestionRun[],
+): SuggestionPair[] {
+  const pairs: SuggestionPair[] = [];
+
+  for (let index = 1; index < runs.length; index++) {
+    // The loop bounds prove these exist; the assertions are only for
+    // noUncheckedIndexedAccess, not runtime uncertainty.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const deletion = runs[index - 1]!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const insertion = runs[index]!;
+
+    // Only deletion -> insertion can cancel into ordinary content. Reversed or
+    // differently-id'd neighbors are separate suggestions, even if adjacent.
+    if (
+      deletion.kind !== "deletion" ||
+      insertion.kind !== "insertion" ||
+      deletion.id !== insertion.id ||
+      deletion.to !== insertion.from
+    ) {
+      continue;
+    }
+
+    pairs.push({ deletion, insertion });
+  }
+
+  return pairs;
+}

--- a/src/features/cleanupNoopMarkPairs/types.ts
+++ b/src/features/cleanupNoopMarkPairs/types.ts
@@ -1,0 +1,34 @@
+import { type Node } from "prosemirror-model";
+
+import { type SuggestionId } from "../../generateId.js";
+
+export interface Range {
+  from: number;
+  to: number;
+}
+
+// used to represent a range of inline content inside a textblock node
+export type TextblockRange = Range;
+
+// represents a node of type text with it's starting and ending positions
+export interface TextSegment {
+  from: number;
+  to: number;
+  node: Node;
+}
+
+// a contigious sequence of either deletion or insertion marks, spread across text nodes
+export interface SuggestionRun {
+  kind: "deletion" | "insertion";
+  id: SuggestionId;
+  from: number;
+  to: number;
+  segments: TextSegment[];
+}
+
+// a contigious sequence of deletion then insertion marks
+// a "deletion/insertion mark pair"
+export interface SuggestionPair {
+  deletion: SuggestionRun;
+  insertion: SuggestionRun;
+}

--- a/src/getChangedRanges.ts
+++ b/src/getChangedRanges.ts
@@ -1,0 +1,106 @@
+// https://github.com/ueberdosis/tiptap/blob/c4c5e16b65b27688a9cd3217ab40f86f023f7a22/packages/core/src/helpers/getChangedRanges.ts#L38
+
+import type { Step, Transform } from "prosemirror-transform";
+
+export interface ChangedRange {
+  oldRange: Range;
+  newRange: Range;
+}
+
+interface Range {
+  from: number;
+  to: number;
+}
+
+/**
+ * Removes duplicated ranges and ranges that are
+ * fully captured by other ranges.
+ */
+function simplifyChangedRanges(changes: ChangedRange[]): ChangedRange[] {
+  const uniqueChanges = removeDuplicates(changes);
+
+  return uniqueChanges.length === 1
+    ? uniqueChanges
+    : uniqueChanges.filter((change, index) => {
+        const rest = uniqueChanges.filter((_, i) => i !== index);
+
+        return !rest.some((otherChange) => {
+          return (
+            change.oldRange.from >= otherChange.oldRange.from &&
+            change.oldRange.to <= otherChange.oldRange.to &&
+            change.newRange.from >= otherChange.newRange.from &&
+            change.newRange.to <= otherChange.newRange.to
+          );
+        });
+      });
+}
+
+/**
+ * Returns a list of changed ranges
+ * based on the first and last state of all steps.
+ */
+export function getChangedRanges(transform: Transform): ChangedRange[] {
+  const { mapping, steps } = transform;
+  const changes: ChangedRange[] = [];
+
+  mapping.maps.forEach((stepMap, index) => {
+    const ranges: Range[] = [];
+
+    // This accounts for step changes where no range was actually altered
+    // e.g. when setting a mark, node attribute, etc.
+    // @ts-expect-error ranges exist
+    if (!(stepMap.ranges as Range[]).length) {
+      const { from, to } = steps[index] as Step & {
+        from?: number;
+        to?: number;
+      };
+
+      if (from === undefined || to === undefined) {
+        return;
+      }
+
+      ranges.push({ from, to });
+    } else {
+      stepMap.forEach((from, to) => {
+        ranges.push({ from, to });
+      });
+    }
+
+    ranges.forEach(({ from, to }) => {
+      const newStart = mapping.slice(index).map(from, -1);
+      const newEnd = mapping.slice(index).map(to);
+      const oldStart = mapping.invert().map(newStart, -1);
+      const oldEnd = mapping.invert().map(newEnd);
+
+      changes.push({
+        oldRange: {
+          from: oldStart,
+          to: oldEnd,
+        },
+        newRange: {
+          from: newStart,
+          to: newEnd,
+        },
+      });
+    });
+  });
+
+  return simplifyChangedRanges(changes);
+}
+
+/**
+ * Removes duplicated values within an array.
+ * Supports numbers, strings and objects.
+ */
+export function removeDuplicates<T>(array: T[], by = JSON.stringify): T[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const seen: Record<any, any> = {};
+
+  return array.filter((item) => {
+    const key = by(item);
+
+    return Object.prototype.hasOwnProperty.call(seen, key)
+      ? false
+      : (seen[key] = true);
+  });
+}

--- a/src/prependDeletionsWithZWSP.ts
+++ b/src/prependDeletionsWithZWSP.ts
@@ -1,4 +1,4 @@
-import { type Transaction } from "prosemirror-state";
+import { TextSelection, type Transaction } from "prosemirror-state";
 import { getSuggestionMarks } from "./utils.js";
 import { Transform } from "prosemirror-transform";
 import { ZWSP } from "./constants.js";
@@ -11,6 +11,13 @@ function trace(...args: unknown[]) {
   console.log("[prependDeletionsWithZWSP]", ...args);
 }
 
+/**
+ * When deletion marks are hidden, and we have a textblock with all of it's contents deleted,
+ * the cursor is invisible inside that textblock
+ * This function finds deletions that start at the node boundary
+ * and prepends them with ZWSP deletion marks that are not hidden
+ * so they act like anchors where the cursor become visible
+ */
 export function prependDeletionsWithZWSP(
   transaction: Transaction,
 ): Transaction {
@@ -70,5 +77,46 @@ export function prependDeletionsWithZWSP(
       transform,
     );
 
+  maybeIncludeAnchorDeletionInSelection(transaction);
+
   return transaction;
+}
+
+/**
+ * After adding anchor deletions, we might have a situation when transaction selection, previously valid,
+ * now became invalid, because selection is now located between "anchor deletion" and "normal deletion"
+ * so check if that's the case and include the anchor deletion into selection
+ */
+function maybeIncludeAnchorDeletionInSelection(transaction: Transaction) {
+  const { deletion } = getSuggestionMarks(transaction.doc.type.schema);
+  // when selection starts exactly after an anchor deletion,
+  // expand the left end of the selection to include the anchor deletion
+  const selection = transaction.selection;
+  if (selection instanceof TextSelection && !selection.empty) {
+    const $from = transaction.doc.resolve(selection.from);
+    const nodeBefore = $from.nodeBefore;
+    const nodeAfter = $from.nodeAfter;
+    const anchorMark = nodeBefore?.marks.find(
+      (mark) => mark.type === deletion && mark.attrs["type"] === "anchor",
+    );
+    const deletionAfter = nodeAfter?.marks.find(
+      (mark) => mark.type === deletion && mark.attrs["type"] !== "anchor",
+    );
+    if (
+      nodeBefore?.isText &&
+      nodeBefore.text === ZWSP &&
+      anchorMark &&
+      deletionAfter &&
+      anchorMark.attrs["id"] === deletionAfter.attrs["id"]
+    ) {
+      const expandedFrom = selection.from - nodeBefore.nodeSize;
+      const anchor =
+        selection.anchor === selection.from ? expandedFrom : selection.anchor;
+      const head =
+        selection.head === selection.from ? expandedFrom : selection.head;
+      transaction.setSelection(
+        TextSelection.create(transaction.doc, anchor, head),
+      );
+    }
+  }
 }

--- a/src/rebasePos.ts
+++ b/src/rebasePos.ts
@@ -7,10 +7,10 @@ import { type Step } from "prosemirror-transform";
  * @param back The old steps to undo, in the order they were originally applied
  * @param forth The new steps to map through
  */
-export function rebasePos(pos: number, back: Step[], forth: Step[]) {
+export function rebasePos(pos: number, back: Step[], forth: Step[], assoc = 1) {
   const reset = back
     .slice()
     .reverse()
-    .reduce((acc, step) => step.getMap().invert().map(acc), pos);
-  return forth.reduce((acc, step) => step.getMap().map(acc), reset);
+    .reduce((acc, step) => step.getMap().invert().map(acc, assoc), pos);
+  return forth.reduce((acc, step) => step.getMap().map(acc, assoc), reset);
 }

--- a/src/withSuggestChanges.ts
+++ b/src/withSuggestChanges.ts
@@ -13,6 +13,8 @@ import {
 import { type StructuralContextPath } from "./features/wrapUnwrap/types.js";
 import { handleSpecialTransactionShape } from "./features/transactionShaping/index.js";
 import { transformToSuggestionTransaction } from "./transformToSuggestionTransaction.js";
+import { getChangedRanges } from "./getChangedRanges.js";
+import { cleanupNoopDeletionInsertionPairs } from "./features/cleanupNoopMarkPairs/index.js";
 
 export { transformToSuggestionTransaction } from "./transformToSuggestionTransaction.js";
 export { suggestStructureChanges } from "./features/wrapUnwrap/structureChangesPlugin.js";
@@ -182,6 +184,11 @@ export function withSuggestChanges(
     }
 
     if (transaction.docChanged) {
+      const changedRanges = getChangedRanges(transaction);
+      cleanupNoopDeletionInsertionPairs(
+        transaction,
+        changedRanges.map((range) => range.newRange),
+      );
       prependDeletionsWithZWSP(transaction);
     }
 

--- a/test-fixtures/keyboard-test.ts
+++ b/test-fixtures/keyboard-test.ts
@@ -12,6 +12,7 @@ import {
   chainCommands,
   exitCode,
   lift,
+  toggleMark,
   wrapIn,
 } from "prosemirror-commands";
 import { keymap } from "prosemirror-keymap";
@@ -123,6 +124,7 @@ let state = EditorState.create({
       "Shift-Tab": liftListItem(schema.nodes.listItem),
       "Mod-u": wrapIn(schema.nodes.blockquote),
       "Mod-l": lift,
+      "Mod-b": toggleMark(schema.marks.strong),
     }),
     inputRules({
       rules: [


### PR DESCRIPTION
Related to 
https://linear.app/letterassembly/issue/MAR-1756/cmdb-does-not-unbold-marked-text-consistently
https://linear.app/letterassembly/issue/MAR-1757/applying-bold-at-paragraph-start-shifts-selection
https://github.com/Magic-Marker/marker/pull/1356

## Summary

Fixes stale suggestion marks left behind when a tracked deletion/insertion pair no longer represents a meaningful change.

For example, when we first make text bold, we get:

```html
<del>foo</del><ins><b>foo</b></ins>
```

That means "replace `foo` with bold `foo`." But if we unbold `foo`, we can end up with:

```html
<del>foo</del><ins>foo</ins>
```

That no longer represents a meaningful replacement: nothing has really changed.

This adds a changed-range-scoped cleanup pass that:

- Finds adjacent deletion -> insertion suggestion pairs in touched textblocks
- Filters them to no-op pairs by comparing inline content after removing suggestion marks
- Cleans them up by keeping the deletion-side content, removing its deletion mark, and deleting the duplicate insertion-side content
- Runs before deletion ZWSP anchoring so cleaned-up deletions do not get anchor marks

It also fixes selection preservation around deletion-anchor ZWSPs. When a tracked replacement starts at the beginning of a textblock, the plugin prepends a deletion-anchor ZWSP before the deleted content. The selection now expands to include that anchor instead of landing between the anchor and deletion. This keeps whole-textblock formatting behavior consistent with partial-textblock formatting and prevents the cursor from ending up one character into the inserted replacement after collapsing the selection.

This PR also adds domain docs and an ADR for the centralized cleanup decision.

## Changes

- Added `cleanupNoopMarkPairs` feature module
- Added `getChangedRanges` helper for transaction-scoped cleanup
- Wired cleanup into `withSuggestChanges`
- Preserved selections around prepended deletion-anchor ZWSPs
- Added Playwright repro coverage for bold/unbold and whole-textblock bolding with track changes enabled
- Added focused unit tests for pair finding and cleanup behavior
- Documented the feature vocabulary and ADR
